### PR TITLE
Replace scanning sysfs tree with netlink for device search

### DIFF
--- a/plugins/eni/engine/error.go
+++ b/plugins/eni/engine/error.go
@@ -46,26 +46,6 @@ func newUnmappedMACAddressError(operation string, origin string, message string)
 	}
 }
 
-// unmappedDeviceNameError is used to indicate that the the MAC address of the
-// ENI cannot be mapped to any of the network devices available on the host
-type unmappedDeviceNameError struct {
-	err *_error
-}
-
-func (devNameErr *unmappedDeviceNameError) Error() string {
-	return devNameErr.err.Error()
-}
-
-func newUnmappedDeviceNameError(operation string, origin string, message string) error {
-	return &unmappedDeviceNameError{
-		err: &_error{
-			operation: operation,
-			origin:    origin,
-			message:   message,
-		},
-	}
-}
-
 // parseIPV4GatewayNetmaskError is used to indicate any error with parsing the
 // IPV4 address and the netmask of the ENI
 type parseIPV4GatewayNetmaskError struct {

--- a/plugins/eni/engine/nsclosure.go
+++ b/plugins/eni/engine/nsclosure.go
@@ -152,7 +152,8 @@ func constructDHClientLeasePIDFilePath(deviceName string) string {
 func (closure *teardownNamespaceClosure) run(_ ns.NetNS) error {
 	link, err := getLinkByHardwareAddress(closure.netLink, closure.hardwareAddr)
 	if err != nil {
-		return err
+		return errors.Wrapf(err,
+			"teardownNamespaceClosure engine: unable to get device with hardware address '%s'", closure.hardwareAddr.String())
 	}
 
 	deviceName := link.Attrs().Name
@@ -190,8 +191,7 @@ func (closure *teardownNamespaceClosure) run(_ ns.NetNS) error {
 func getLinkByHardwareAddress(netLink netlinkwrapper.NetLink, hardwareAddr net.HardwareAddr) (netlink.Link, error) {
 	links, err := netLink.LinkList()
 	if err != nil {
-		errors.Wrapf(err,
-			"teardownNamespaceClosure engine: unable to list device and attributes")
+		return nil, err
 	}
 
 	for _, link := range links {


### PR DESCRIPTION
### Summary

plugins/eni/engine: replace scanning sysfs tree with netlink for device search

Use netlink.LinkList instead of browsing the sysfs subtree to determine the
device name of the ENI. This is much cleaner than the earlier implementation,
which involved reading directories and files.

### Testing Done
- [X] `make plugins`
- [X] `make unit-tests`
- [X] Manual testing: Ran the ENI plugin on an EC2 Instance, and verified that there's no regression