### PR TITLE
pkg/logger: add rotating file logger

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,70 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logger
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	log "github.com/cihub/seelog"
+)
+
+const (
+	envLogLevel    = "ECS_CNI_LOGLEVEL"
+	envLogFilePath = "ECS_CNI_LOG_FILE"
+	// logConfigFormat defines the seelog format, with a rolling file
+	// writer. We cannot do this in code and have to resort to using
+	// LoggerFromConfigAsString as seelog doesn't have a usable public
+	// implementation of NewRollingFileWriterTime
+	logConfigFormat = `
+<seelog type="asyncloop" minlevel="%s">
+ <outputs formatid="main">
+  <rollingfile filename="%s" type="date" datepattern="2006-01-02-15" archivetype="none" maxrolls="24" />
+ </outputs>
+ <formats>
+  <format id="main" format="%%UTCDate(2006-01-02T15:04:05Z07:00) [%%LEVEL] %%Msg%%n" />
+ </formats>
+</seelog>
+`
+)
+
+// GetLogFileLocation returns the log file path
+func GetLogFileLocation(defaultLogFilePath string) string {
+	logFilePath := os.Getenv(envLogFilePath)
+	if logFilePath == "" {
+		logFilePath = defaultLogFilePath
+	}
+
+	return logFilePath
+}
+
+// SetupLogger sets up a file logger
+func SetupLogger(logFilePath string) {
+	logger, err := log.LoggerFromConfigAsString(fmt.Sprintf(logConfigFormat, getLogLevel(), logFilePath))
+	if err != nil {
+		fmt.Println("Error setting up logger: ", err)
+		return
+	}
+	log.ReplaceLogger(logger)
+}
+
+func getLogLevel() string {
+	seelogLevel, ok := log.LogLevelFromString(strings.ToLower(os.Getenv(envLogLevel)))
+	if !ok {
+		seelogLevel = log.InfoLvl
+	}
+
+	return seelogLevel.String()
+}

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,59 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logger
+
+import (
+	"os"
+	"testing"
+
+	log "github.com/cihub/seelog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLogFileLocationReturnsOverriddenPath(t *testing.T) {
+	path := "/tmp/foo"
+	os.Setenv(envLogFilePath, path)
+	defer os.Unsetenv(envLogFilePath)
+
+	assert.Equal(t, path, GetLogFileLocation("/tmp/bar"))
+}
+
+func TestGetLogFileLocationReturnsDefaultPath(t *testing.T) {
+	path := "/tmp/foo"
+	assert.Equal(t, path, GetLogFileLocation(path))
+}
+
+func TestLogLevelReturnsOverriddenLevel(t *testing.T) {
+	os.Setenv(envLogLevel, "DEBUG")
+	defer os.Unsetenv(envLogLevel)
+
+	var expectedLogLevel log.LogLevel
+	expectedLogLevel = log.DebugLvl
+	assert.Equal(t, expectedLogLevel.String(), getLogLevel())
+}
+
+func TestLogLevelReturnsDefaultLevelWhenEnvNotSet(t *testing.T) {
+	var expectedLogLevel log.LogLevel
+	expectedLogLevel = log.InfoLvl
+	assert.Equal(t, expectedLogLevel.String(), getLogLevel())
+}
+
+func TestLogLevelReturnsDefaultLevelWhenEnvSetToInvalidValue(t *testing.T) {
+	os.Setenv(envLogLevel, "DEBUGGER")
+	defer os.Unsetenv(envLogLevel)
+
+	var expectedLogLevel log.LogLevel
+	expectedLogLevel = log.InfoLvl
+	assert.Equal(t, expectedLogLevel.String(), getLogLevel())
+}

--- a/plugins/eni/main.go
+++ b/plugins/eni/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/aws/amazon-ecs-cni-plugins/pkg/logger"
 	"github.com/aws/amazon-ecs-cni-plugins/pkg/version"
 	"github.com/aws/amazon-ecs-cni-plugins/plugins/eni/commands"
 	"github.com/aws/amazon-ecs-cni-plugins/plugins/eni/version/cnispec"
@@ -25,13 +26,17 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 )
 
+const (
+	defaultLogFilePath = "/var/log/ecs/ecs-cni-eni-plugin.log"
+)
+
 func init() {
 	runtime.LockOSThread()
 }
 
 func main() {
-	// TODO logging config
 	defer log.Flush()
+	logger.SetupLogger(logger.GetLogFileLocation(defaultLogFilePath))
 
 	var printVersion bool
 	flag.BoolVar(&printVersion, "version", false, "prints version and exits")

--- a/plugins/ipam/main.go
+++ b/plugins/ipam/main.go
@@ -17,6 +17,7 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/aws/amazon-ecs-cni-plugins/pkg/logger"
 	"github.com/aws/amazon-ecs-cni-plugins/pkg/version"
 	"github.com/aws/amazon-ecs-cni-plugins/plugins/ipam/commands"
 	"github.com/aws/amazon-ecs-cni-plugins/plugins/ipam/version/cnispec"
@@ -24,9 +25,13 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 )
 
+const (
+	defaultLogFilePath = "/var/log/ecs/ecs-cni-ipam-plugin.log"
+)
+
 func main() {
-	// TODO logging config
 	defer log.Flush()
+	logger.SetupLogger(logger.GetLogFileLocation(defaultLogFilePath))
 
 	var printVersion bool
 	flag.BoolVar(&printVersion, "version", false, "prints version and exits")
@@ -43,7 +48,7 @@ func main() {
 func printVersionInfo() {
 	versionInfo, err := version.String()
 	if err != nil {
-		fmt.Println("Error getting version string: ", err)
+		log.Errorf("Error getting version string: %v", err)
 		return
 	}
 	fmt.Println(versionInfo)


### PR DESCRIPTION
### Summary
* Add rotating file logger
* Should resolve #8 and #9
### Testing Done
- [X] `make plugins`
- [X] `make unit-test`
- [X] Manual tests: Verified that the log file gets created in the appropriate location:
```
$ ls -l /var/log/ecs/ecs-cni-ipam-plugin.log
-rw-r--r-- 1 aithal xxxx 95 Mar 31 21:36 /var/log/ecs/ecs-cni-ipam-plugin.log
```