### PR TITLE
Change the value of ipam key-value pair to id that can be more useful instead of timestamps

### DIFF
--- a/plugins/eni/version/cnispec/spec.go
+++ b/plugins/eni/version/cnispec/spec.go
@@ -16,14 +16,14 @@ package cnispec
 import "github.com/containernetworking/cni/pkg/version"
 
 // specVersionSupported is the version of the CNI spec that's supported by the
-// ENI plugin. It's set to 0.2.0, which means that we support the following
+// ENI plugin. It's set to 0.3.0, which means that we support the following
 // commands:
 // * ADD
 // * DELETE
 // * VERSION
 // Refer to https://github.com/containernetworking/cni/blob/master/SPEC.md
 // for details
-var specVersionSupported = version.PluginSupports("0.2.0")
+var specVersionSupported = version.PluginSupports("0.3.0")
 
 // GetSpecVersionSupported gets the version of the CNI spec that's supported
 // by the ENI plugin

--- a/plugins/ipam/README.md
+++ b/plugins/ipam/README.md
@@ -8,7 +8,8 @@ network namespace. An example of this configuration looks like:
 ```json
 {
     "ipam": {
-       "type": "ipam",
+        "type": "ipam",
+        "id": "12345",
         "ipv4-address": "10.0.0.2/24",
         "ipv4-gateway": "10.0.0.1",
         "ipv4-subnet": "10.0.0.0/24",
@@ -20,6 +21,8 @@ network namespace. An example of this configuration looks like:
 }
 ```
 ## Parameter
+* `id` (string, optional): information about this ip, can be any information related
+to this ip.
 * `ipv4-address` (string, optional): ipv4 address of the veth inside the
 container network namespace.
 * `ipv4-routes` (string, optional): list of routes to add to the container network

--- a/plugins/ipam/commands/commands.go
+++ b/plugins/ipam/commands/commands.go
@@ -15,7 +15,6 @@ package commands
 
 import (
 	"net"
-	"time"
 
 	"github.com/aws/amazon-ecs-cni-plugins/plugins/ipam/config"
 	"github.com/aws/amazon-ecs-cni-plugins/plugins/ipam/ipstore"
@@ -131,7 +130,7 @@ func getIPV4Address(ipManager ipstore.IPAllocator, conf *config.IPAMConfig) (*ne
 	if assignedAddress.IP != nil {
 		// IP was specifed in the configuration, try to assign this ip as used
 		// if this ip has already been used, it will return an error
-		err := ipManager.Assign(assignedAddress.IP.String(), time.Now().UTC().String())
+		err := ipManager.Assign(assignedAddress.IP.String(), conf.ID)
 		if err != nil {
 			return nil, errors.Wrapf(err, "getIPV4Address commands: failed to mark this ip %v as used", assignedAddress)
 		}
@@ -163,7 +162,7 @@ func getIPV4AddressFromDB(ipManager ipstore.IPAllocator, conf *config.IPAMConfig
 	}
 
 	ipManager.SetLastKnownIP(startIP)
-	nextIP, err := ipManager.GetAvailableIP(time.Now().UTC().String())
+	nextIP, err := ipManager.GetAvailableIP(conf.ID)
 	if err != nil {
 		return "", errors.Wrap(err, "getIPV4AddressFromDB commands: failed to get available ip from the db")
 	}

--- a/plugins/ipam/config/config.go
+++ b/plugins/ipam/config/config.go
@@ -44,6 +44,7 @@ type IPAMConfig struct {
 	IPV4Address types.IPNet    `json:"ipv4-address,omitempty"`
 	IPV4Gateway net.IP         `json:"ipv4-gateway,omitempty"`
 	IPV4Routes  []*types.Route `json:"ipv4-routes,omitempty"`
+	ID          string         `json:id,omitempty`
 }
 
 // Conf stores the option from configuration file
@@ -60,7 +61,7 @@ func LoadIPAMConfig(bytes []byte, args string) (*IPAMConfig, string, error) {
 	ipamConf := &Conf{}
 
 	if err := json.Unmarshal(bytes, &ipamConf); err != nil {
-		return nil, "", errors.Wrapf(err, "loadIPAMConfig config: 'failed to load netconf")
+		return nil, "", errors.Wrapf(err, "loadIPAMConfig config: failed to load netconf, %s", string(bytes))
 	}
 	if ipamConf.IPAM == nil {
 		return nil, "", errors.New("loadIPAMConfig config: 'IPAM' field missing in configuration")

--- a/plugins/ipam/ipstore/ipstore.go
+++ b/plugins/ipam/ipstore/ipstore.go
@@ -90,7 +90,7 @@ func (manager *IPManager) GetAvailableIP(id string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		err = manager.Assign(nextIP.String(), time.Now().UTC().String())
+		err = manager.Assign(nextIP.String(), id)
 		if err != nil && err != store.ErrKeyExists {
 			log.Debugf("query to the db failed, err: %v", err)
 			return "", err


### PR DESCRIPTION
Fix #22 and #5 issue, where ipam plugin will store the id passed in as the value instead of the  timestamps, also added the function that ipam can release the ip address by this id.

Manually tested with both setup and cleanup as in this PR: aws/amazon-ecs-agent/#779