### PR TITLE
Makefile: add ecs- prefix for eni and ipam plugins.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 SOURCEDIR=./pkg ./plugins
 SOURCES := $(shell find $(SOURCEDIR) -name '*.go')
 ROOT := $(shell pwd)
-LOCAL_ENI_PLUGIN_BINARY=bin/plugins/eni
-LOCAL_IPAM_PLUGIN_BINARY=bin/plugins/ipam
+LOCAL_ENI_PLUGIN_BINARY=bin/plugins/ecs-eni
+LOCAL_IPAM_PLUGIN_BINARY=bin/plugins/ecs-ipam
 LOCAL_BRIDGE_PLUGIN_BINARY=bin/plugins/ecs-bridge
 GIT_PORCELAIN=$(shell git status --porcelain | wc -l)
 GIT_SHORT_HASH=$(shell git rev-parse --short HEAD)
@@ -23,7 +23,7 @@ $(LOCAL_ENI_PLUGIN_BINARY): $(SOURCES)
 	     -X github.com/aws/amazon-ecs-cni-plugins/pkg/version.GitShortHash=$(GIT_SHORT_HASH) \
 	     -X github.com/aws/amazon-ecs-cni-plugins/pkg/version.GitPorcelain=$(GIT_PORCELAIN) \
 	     -X github.com/aws/amazon-ecs-cni-plugins/pkg/version.Version=$(VERSION) -s" \
-	     -o ${ROOT}/bin/plugins/eni github.com/aws/amazon-ecs-cni-plugins/plugins/eni
+	     -o ${ROOT}/${LOCAL_ENI_PLUGIN_BINARY} github.com/aws/amazon-ecs-cni-plugins/plugins/eni
 	@echo "Built eni plugin"
 
 $(LOCAL_IPAM_PLUGIN_BINARY): $(SOURCES)
@@ -31,7 +31,7 @@ $(LOCAL_IPAM_PLUGIN_BINARY): $(SOURCES)
 	     -X github.com/aws/amazon-ecs-cni-plugins/pkg/version.GitShortHash=$(GIT_SHORT_HASH) \
 	     -X github.com/aws/amazon-ecs-cni-plugins/pkg/version.GitPorcelain=$(GIT_PORCELAIN) \
 	     -X github.com/aws/amazon-ecs-cni-plugins/pkg/version.Version=$(VERSION) -s" \
-	     -o ${ROOT}/bin/plugins/ipam github.com/aws/amazon-ecs-cni-plugins/plugins/ipam
+	     -o ${ROOT}/${LOCAL_IPAM_PLUGIN_BINARY} github.com/aws/amazon-ecs-cni-plugins/plugins/ipam
 	@echo "Built ipam plugin"
 
 $(LOCAL_BRIDGE_PLUGIN_BINARY): $(SOURCES)


### PR DESCRIPTION
Should fix #38 

### Testing Done
- [X] Build succeeds
- [X] Unit tests pass 
- [X] Inspected artifacts manually
```bash
$ make clean plugins
rm -rf /local/home/aithal/workspace/src/github.com/aws/amazon-ecs-cni-plugins/bin ||:
GOOS=linux CGO_ENABLED=0 go build -installsuffix cgo -a -ldflags "\
             -X github.com/aws/amazon-ecs-cni-plugins/pkg/version.GitShortHash=5fc1911 \
             -X github.com/aws/amazon-ecs-cni-plugins/pkg/version.GitPorcelain=0 \
             -X github.com/aws/amazon-ecs-cni-plugins/pkg/version.Version=0.1.0 -s" \
             -o /local/home/aithal/workspace/src/github.com/aws/amazon-ecs-cni-plugins/bin/plugins/ecs-eni github.com/aws/amazon-ecs-cni-plugins/plugins/eni
Built eni plugin
GOOS=linux CGO_ENABLED=0 go build -installsuffix cgo -a -ldflags "\
             -X github.com/aws/amazon-ecs-cni-plugins/pkg/version.GitShortHash=5fc1911 \
             -X github.com/aws/amazon-ecs-cni-plugins/pkg/version.GitPorcelain=0 \
             -X github.com/aws/amazon-ecs-cni-plugins/pkg/version.Version=0.1.0 -s" \
             -o /local/home/aithal/workspace/src/github.com/aws/amazon-ecs-cni-plugins/bin/plugins/ecs-ipam github.com/aws/amazon-ecs-cni-plugins/plugins/ipam
Built ipam plugin

$ ls bin/plugins/
ecs-eni  ecs-ipam
```