### PR TITLE
Fixing the bridge return result and the path of log file and ipam store

### DIFF
--- a/plugins/ecs-bridge/commands/commands.go
+++ b/plugins/ecs-bridge/commands/commands.go
@@ -100,7 +100,7 @@ func add(args *skel.CmdArgs, engine engine.Engine) error {
 	if err != nil {
 		return err
 	}
-	return nil
+	return result.Print()
 }
 
 func del(args *skel.CmdArgs, engine engine.Engine) error {

--- a/plugins/ecs-bridge/main.go
+++ b/plugins/ecs-bridge/main.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	defaultLogFilePath = "/var/log/ecs/ecs-cni-bridge-plugin.log"
+	defaultLogFilePath = "/log/ecs-cni-bridge-plugin.log"
 )
 
 func init() {

--- a/plugins/eni/main.go
+++ b/plugins/eni/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	defaultLogFilePath = "/var/log/ecs/ecs-cni-eni-plugin.log"
+	defaultLogFilePath = "/log/ecs-cni-eni-plugin.log"
 )
 
 func init() {

--- a/plugins/ipam/config/config.go
+++ b/plugins/ipam/config/config.go
@@ -31,7 +31,7 @@ const (
 	EnvIpamTimeout           = "IPAM_DB_CONNECTION_TIMEOUT"
 	LastKnownIPKey           = "lastKnownIP"
 	GatewayValue             = "GateWay"
-	DefaultDBPath            = "/var/lib/ecs/data/ipam"
+	DefaultDBPath            = "/data/ipam"
 	BucketName               = "IPAM"
 	DefaultConnectionTimeout = 5 * time.Second
 )

--- a/plugins/ipam/main.go
+++ b/plugins/ipam/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	defaultLogFilePath = "/var/log/ecs/ecs-cni-ipam-plugin.log"
+	defaultLogFilePath = "/log/ecs-cni-ipam-plugin.log"
 )
 
 func main() {


### PR DESCRIPTION
The agent mount` /var/lib/ecs/data` as `/data`, change the default ipam path to `/data/ipam` so that it will persistent in `/var/lib/ecs/data` on the host.
Also the `/var/log/ecs` was mounted as `/log` inside agent.