### PR TITLE
Add a parameter in ENI plugin to block Instance Metadata Service access

### DIFF
--- a/plugins/eni/README.md
+++ b/plugins/eni/README.md
@@ -12,7 +12,8 @@ An example configuration for invoking the plugin is listed next:
     "cniVersion":"0.3.0",
     "eni":"eni-eni01en1",
     "ipv4-address":"172.31.31.65/20",
-    "mac":"01:23:45:67:89:ab"
+    "mac":"01:23:45:67:89:ab",
+    "block-instance-metadata":true
 }
 ```
 
@@ -22,6 +23,8 @@ An example configuration for invoking the plugin is listed next:
 Primary private IPV4 address of the interface
 * `mac` (string, required): the MAC address of the ENI
 * `ipv6-address` (string, optional): the ipv6 address of the ENI
+* `block-instance-metadata` (bool, optional): specifies if the route to EC2 
+instance metadata should be blocked
 
 ## Environment Variables
 * `ENI_DHCLIENT_LEASES_PATH` (string, optional): the dhclient leases file path.

--- a/plugins/eni/commands/commands.go
+++ b/plugins/eni/commands/commands.go
@@ -130,7 +130,8 @@ func add(args *skel.CmdArgs, engine engine.Engine, dhclient engine.DHClient) err
 	// the network namespace of the ENI. Invoke SetupContainerNamespace to
 	// do the same
 	err = engine.SetupContainerNamespace(args.Netns, networkDeviceName,
-		fmt.Sprintf("%s/%s", conf.IPV4Address, ipv4Netmask), ipv6Address, ipv4Gateway, ipv6Gateway, dhclient)
+		fmt.Sprintf("%s/%s", conf.IPV4Address, ipv4Netmask),
+		ipv6Address, ipv4Gateway, ipv6Gateway, dhclient, conf.BlockIMDS)
 	if err != nil {
 		log.Errorf("Unable to setup container's namespace: %v", err)
 		return err

--- a/plugins/eni/commands/commands_test.go
+++ b/plugins/eni/commands/commands_test.go
@@ -336,7 +336,8 @@ func TestAddSetupContainerNamespaceFails(t *testing.T) {
 		mockEngine.EXPECT().GetIPV4GatewayNetmask(macAddress).Return(eniIPV4Gateway, eniIPV4SubnetMask, nil),
 		mockEngine.EXPECT().GetIPV6PrefixLength(macAddress).Return(eniIPV6SubnetMask, nil),
 		mockEngine.EXPECT().GetIPV6Gateway(deviceName).Return(eniIPV6Gateway, nil),
-		mockEngine.EXPECT().SetupContainerNamespace(nsName, deviceName, eniIPV4AddressWithSubnetMask, eniIPV6AddressWithSubnetMask, eniIPV4Gateway, eniIPV6Gateway, mockDHClient).Return(errors.New("error")),
+		mockEngine.EXPECT().SetupContainerNamespace(nsName, deviceName, eniIPV4AddressWithSubnetMask,
+			eniIPV6AddressWithSubnetMask, eniIPV4Gateway, eniIPV6Gateway, mockDHClient, false).Return(errors.New("error")),
 	)
 
 	err := add(eniArgs, mockEngine, mockDHClient)
@@ -358,7 +359,8 @@ func TestAddSetupContainerNamespaceFailsNoIPV6(t *testing.T) {
 		mockEngine.EXPECT().DoesMACAddressMapToIPV4Address(macAddress, eniIPV4Address).Return(true, nil),
 		mockEngine.EXPECT().GetInterfaceDeviceName(macAddress).Return(deviceName, nil),
 		mockEngine.EXPECT().GetIPV4GatewayNetmask(macAddress).Return(eniIPV4Gateway, eniIPV4SubnetMask, nil),
-		mockEngine.EXPECT().SetupContainerNamespace(nsName, deviceName, eniIPV4AddressWithSubnetMask, "", eniIPV4Gateway, "", mockDHClient).Return(errors.New("error")),
+		mockEngine.EXPECT().SetupContainerNamespace(nsName, deviceName, eniIPV4AddressWithSubnetMask, "",
+			eniIPV4Gateway, "", mockDHClient, false).Return(errors.New("error")),
 	)
 
 	err := add(eniArgsNoIPV6, mockEngine, mockDHClient)
@@ -383,7 +385,8 @@ func TestAddNoError(t *testing.T) {
 		mockEngine.EXPECT().GetIPV4GatewayNetmask(macAddress).Return(eniIPV4Gateway, eniIPV4SubnetMask, nil),
 		mockEngine.EXPECT().GetIPV6PrefixLength(macAddress).Return(eniIPV6SubnetMask, nil),
 		mockEngine.EXPECT().GetIPV6Gateway(deviceName).Return(eniIPV6Gateway, nil),
-		mockEngine.EXPECT().SetupContainerNamespace(nsName, deviceName, eniIPV4AddressWithSubnetMask, eniIPV6AddressWithSubnetMask, eniIPV4Gateway, eniIPV6Gateway, mockDHClient).Return(nil),
+		mockEngine.EXPECT().SetupContainerNamespace(nsName, deviceName, eniIPV4AddressWithSubnetMask,
+			eniIPV6AddressWithSubnetMask, eniIPV4Gateway, eniIPV6Gateway, mockDHClient, false).Return(nil),
 	)
 
 	err := add(eniArgs, mockEngine, mockDHClient)
@@ -405,7 +408,8 @@ func TestAddNoErrorWhenIPV6AddressNotSpecifiedInConfig(t *testing.T) {
 		mockEngine.EXPECT().DoesMACAddressMapToIPV4Address(macAddress, eniIPV4Address).Return(true, nil),
 		mockEngine.EXPECT().GetInterfaceDeviceName(macAddress).Return(deviceName, nil),
 		mockEngine.EXPECT().GetIPV4GatewayNetmask(macAddress).Return(eniIPV4Gateway, eniIPV4SubnetMask, nil),
-		mockEngine.EXPECT().SetupContainerNamespace(nsName, deviceName, eniIPV4AddressWithSubnetMask, "", eniIPV4Gateway, "", mockDHClient).Return(nil),
+		mockEngine.EXPECT().SetupContainerNamespace(nsName, deviceName, eniIPV4AddressWithSubnetMask, "",
+			eniIPV4Gateway, "", mockDHClient, false).Return(nil),
 	)
 
 	err := add(eniArgsNoIPV6, mockEngine, mockDHClient)
@@ -440,7 +444,8 @@ func TestAddPrintResult(t *testing.T) {
 		mockEngine.EXPECT().GetIPV4GatewayNetmask(macAddress).Return(eniIPV4Gateway, eniIPV4SubnetMask, nil),
 		mockEngine.EXPECT().GetIPV6PrefixLength(macAddress).Return(eniIPV6SubnetMask, nil),
 		mockEngine.EXPECT().GetIPV6Gateway(deviceName).Return(eniIPV6Gateway, nil),
-		mockEngine.EXPECT().SetupContainerNamespace(nsName, deviceName, eniIPV4AddressWithSubnetMask, eniIPV6AddressWithSubnetMask, eniIPV4Gateway, eniIPV6Gateway, mockDHClient).Return(nil),
+		mockEngine.EXPECT().SetupContainerNamespace(nsName, deviceName, eniIPV4AddressWithSubnetMask,
+			eniIPV6AddressWithSubnetMask, eniIPV4Gateway, eniIPV6Gateway, mockDHClient, false).Return(nil),
 	)
 
 	oldStdout := os.Stdout
@@ -489,7 +494,8 @@ func TestAddPrintResultNoIPV6(t *testing.T) {
 		mockEngine.EXPECT().DoesMACAddressMapToIPV4Address(macAddress, eniIPV4Address).Return(true, nil),
 		mockEngine.EXPECT().GetInterfaceDeviceName(macAddress).Return(deviceName, nil),
 		mockEngine.EXPECT().GetIPV4GatewayNetmask(macAddress).Return(eniIPV4Gateway, eniIPV4SubnetMask, nil),
-		mockEngine.EXPECT().SetupContainerNamespace(nsName, deviceName, eniIPV4AddressWithSubnetMask, "", eniIPV4Gateway, "", mockDHClient).Return(nil),
+		mockEngine.EXPECT().SetupContainerNamespace(nsName, deviceName, eniIPV4AddressWithSubnetMask, "",
+			eniIPV4Gateway, "", mockDHClient, false).Return(nil),
 	)
 
 	oldStdout := os.Stdout

--- a/plugins/eni/engine/engine.go
+++ b/plugins/eni/engine/engine.go
@@ -65,7 +65,7 @@ type Engine interface {
 	GetIPV6Gateway(deviceName string) (string, error)
 	DoesMACAddressMapToIPV4Address(macAddress string, ipv4Address string) (bool, error)
 	DoesMACAddressMapToIPV6Address(macAddress string, ipv4Address string) (bool, error)
-	SetupContainerNamespace(netns string, deviceName string, ipv4Address string, ipv6Address string, ipv4Gateway string, ipv6Gateway string, dhclient DHClient) error
+	SetupContainerNamespace(netns string, deviceName string, ipv4Address string, ipv6Address string, ipv4Gateway string, ipv6Gateway string, dhclient DHClient, blockIMDS bool) error
 	TeardownContainerNamespace(netns string, macAddress string, stopDHClient6 bool, dhclient DHClient) error
 }
 
@@ -319,7 +319,7 @@ func (engine *engine) doesMACAddressMapToIPAddress(macAddress string, addressToF
 // SetupContainerNamespace configures the network namespace of the container with
 // the ipv4 address and routes to use the ENI interface. The ipv4 address is of the
 // ipv4-address/netmask format
-func (engine *engine) SetupContainerNamespace(netns string, deviceName string, ipv4Address string, ipv6Address string, ipv4Gateway string, ipv6Gateway string, dhclient DHClient) error {
+func (engine *engine) SetupContainerNamespace(netns string, deviceName string, ipv4Address string, ipv6Address string, ipv4Gateway string, ipv6Gateway string, dhclient DHClient, blockIMDS bool) error {
 	// Get the device link for the ENI
 	eniLink, err := engine.netLink.LinkByName(deviceName)
 	if err != nil {
@@ -342,7 +342,7 @@ func (engine *engine) SetupContainerNamespace(netns string, deviceName string, i
 	}
 
 	// Generate the closure to execute within the container's namespace
-	toRun, err := newSetupNamespaceClosureContext(engine.netLink, dhclient, deviceName, ipv4Address, ipv6Address, ipv4Gateway, ipv6Gateway)
+	toRun, err := newSetupNamespaceClosureContext(engine.netLink, dhclient, deviceName, ipv4Address, ipv6Address, ipv4Gateway, ipv6Gateway, blockIMDS)
 	if err != nil {
 		return errors.Wrap(err,
 			"setupContainerNamespace engine: unable to create closure to execute in container namespace")

--- a/plugins/eni/engine/engine_test.go
+++ b/plugins/eni/engine/engine_test.go
@@ -692,7 +692,7 @@ func TestSetupContainerNamespaceFailsOnLinkByNameError(t *testing.T) {
 
 	mockNetLink.EXPECT().LinkByName(deviceName).Return(nil, errors.New("error"))
 	engine := &engine{netLink: mockNetLink}
-	err := engine.SetupContainerNamespace("ns1", deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, nil)
+	err := engine.SetupContainerNamespace("ns1", deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, nil, false)
 	assert.Error(t, err)
 }
 
@@ -706,7 +706,7 @@ func TestSetupContainerNamespaceFailsOnGetNSError(t *testing.T) {
 		mockNS.EXPECT().GetNS("ns1").Return(nil, errors.New("error")),
 	)
 	engine := &engine{ns: mockNS, netLink: mockNetLink}
-	err := engine.SetupContainerNamespace("ns1", deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, nil)
+	err := engine.SetupContainerNamespace("ns1", deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, nil, false)
 	assert.Error(t, err)
 }
 
@@ -724,7 +724,7 @@ func TestSetupContainerNamespaceFailsOnLinksetNsFdError(t *testing.T) {
 		mockNetLink.EXPECT().LinkSetNsFd(mockENILink, int(fd)).Return(errors.New("error")),
 	)
 	engine := &engine{ns: mockNS, netLink: mockNetLink}
-	err := engine.SetupContainerNamespace("ns1", deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, nil)
+	err := engine.SetupContainerNamespace("ns1", deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, nil, false)
 	assert.Error(t, err)
 }
 
@@ -743,7 +743,7 @@ func TestSetupContainerNamespaceFailsOnParseAddrError(t *testing.T) {
 		mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(nil, errors.New("error")),
 	)
 	engine := &engine{ns: mockNS, netLink: mockNetLink}
-	err := engine.SetupContainerNamespace("ns1", deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, nil)
+	err := engine.SetupContainerNamespace("ns1", deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, nil, false)
 	assert.Error(t, err)
 }
 
@@ -764,7 +764,7 @@ func TestSetupContainerNamespaceFailsOnWithNetNSPathError(t *testing.T) {
 		mockNS.EXPECT().WithNetNSPath("ns1", gomock.Any()).Return(errors.New("error")),
 	)
 	engine := &engine{ns: mockNS, netLink: mockNetLink}
-	err := engine.SetupContainerNamespace("ns1", deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", nil)
+	err := engine.SetupContainerNamespace("ns1", deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", nil, false)
 	assert.Error(t, err)
 }
 
@@ -785,7 +785,7 @@ func TestSetupContainerNamespaceNoIPV6(t *testing.T) {
 		mockNS.EXPECT().WithNetNSPath("ns1", gomock.Any()).Return(nil),
 	)
 	engine := &engine{ns: mockNS, netLink: mockNetLink}
-	err := engine.SetupContainerNamespace("ns1", deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", nil)
+	err := engine.SetupContainerNamespace("ns1", deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", nil, false)
 	assert.NoError(t, err)
 }
 
@@ -808,7 +808,7 @@ func TestSetupContainerNamespace(t *testing.T) {
 		mockNS.EXPECT().WithNetNSPath("ns1", gomock.Any()).Return(nil),
 	)
 	engine := &engine{ns: mockNS, netLink: mockNetLink}
-	err := engine.SetupContainerNamespace("ns1", deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, nil)
+	err := engine.SetupContainerNamespace("ns1", deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, nil, false)
 	assert.NoError(t, err)
 }
 
@@ -817,7 +817,7 @@ func TestSetupNamespaceClosureCreationFailsOnIPV4ParseAddrError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(nil, errors.New("error"))
-	_, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "")
+	_, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false)
 	assert.Error(t, err)
 }
 
@@ -828,7 +828,7 @@ func TestSetupNamespaceClosureCreationFailsOnIPV4ParseGatewayError(t *testing.T)
 	ipv4Addr := &netlink.Addr{}
 	mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(ipv4Addr, nil)
 	// Gateway is an empty string, so we expect this method to fail
-	_, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, "", "", "")
+	_, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, "", "", "", false)
 	assert.Error(t, err)
 }
 
@@ -841,7 +841,7 @@ func TestSetupNamespaceClosureCreationFailsOnIPV6ParseAddrError(t *testing.T) {
 		mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(ipv4Addr, nil),
 		mockNetLink.EXPECT().ParseAddr(eniIPV6CIDRBlock).Return(nil, errors.New("error")),
 	)
-	_, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway)
+	_, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false)
 	assert.Error(t, err)
 }
 
@@ -856,7 +856,7 @@ func TestSetupNamespaceClosureCreationFailsOnIPV6ParseGatewayError(t *testing.T)
 		mockNetLink.EXPECT().ParseAddr(eniIPV6CIDRBlock).Return(ipv6Addr, nil),
 	)
 	// Gateway is an empty string, so we expect this method to fail
-	_, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, "")
+	_, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, "", false)
 	assert.Error(t, err)
 }
 
@@ -870,7 +870,7 @@ func TestSetupNamespaceClosureRunFailsOnLinkByNameError(t *testing.T) {
 		mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(ipv4Addr, nil),
 		mockNetLink.EXPECT().LinkByName(deviceName).Return(nil, errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "")
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -889,7 +889,7 @@ func TestSetupNamespaceClosureRunFailsOnIPV4AddrAddError(t *testing.T) {
 		mockNetLink.EXPECT().LinkByName(deviceName).Return(mockENILink, nil),
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "")
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -911,7 +911,7 @@ func TestSetupNamespaceClosureRunFailsOnIPV6AddrAddError(t *testing.T) {
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(nil),
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv6Address).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -931,7 +931,34 @@ func TestSetupNamespaceClosureRunFailsOnLinkSetupError(t *testing.T) {
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(nil),
 		mockNetLink.EXPECT().LinkSetUp(mockENILink).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "")
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false)
+	assert.NoError(t, err)
+	assert.NotNil(t, closure)
+	err = closure.run(mockNetNS)
+	assert.Error(t, err)
+}
+
+func TestSetupNamespaceClosureRunFailsOnBlackholeRouteAddError(t *testing.T) {
+	ctrl, _, _, _, mockNetLink, _, _ := setup(t)
+	defer ctrl.Finish()
+
+	mockNetNS := mock_ns.NewMockNetNS(ctrl)
+	mockENILink := mock_netlink.NewMockLink(ctrl)
+	ipv4Address := &netlink.Addr{}
+	_, imdsNetwork, err := net.ParseCIDR(instanceMetadataEndpoint)
+	assert.NoError(t, err)
+	gomock.InOrder(
+		mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(ipv4Address, nil),
+		mockNetLink.EXPECT().LinkByName(deviceName).Return(mockENILink, nil),
+		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(nil),
+		mockNetLink.EXPECT().LinkSetUp(mockENILink).Return(nil),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
+			assert.Nil(t, route.Gw)
+			assert.Equal(t, imdsNetwork.String(), route.Dst.String())
+			assert.Equal(t, syscall.RTN_BLACKHOLE, route.Type)
+		}).Return(errors.New("error")),
+	)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", true)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -954,7 +981,7 @@ func TestSetupNamespaceClosureRunFailsOnIPV4RouteAddError(t *testing.T) {
 			assert.Equal(t, route.Gw.String(), eniIPV4Gateway)
 		}).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "")
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, nil, deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -992,7 +1019,7 @@ func TestSetupNamespaceClosureRunFailsOnDHClientV4CommandCombinedOutputError(t *
 		leasesFilePath: dhclientLeasesFilePathDefault,
 		pidFilePath:    dhclientPIDFilePathDefault,
 	}
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, dhclient, deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "")
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, dhclient, deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -1039,7 +1066,7 @@ func TestSetupNamespaceClosureRunFailsOnIPV6RouteAddError(t *testing.T) {
 		leasesFilePath: dhclientLeasesFilePathDefault,
 		pidFilePath:    dhclientPIDFilePathDefault,
 	}
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, dhclient, deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, dhclient, deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -1095,7 +1122,7 @@ func TestSetupNamespaceClosureRunFailsOnDHClientV6CommandCombinedOutputError(t *
 		leasesFilePath: dhclientLeasesFilePathDefault,
 		pidFilePath:    dhclientPIDFilePathDefault,
 	}
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, dhclient, deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, dhclient, deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -1133,7 +1160,70 @@ func TestSetupNamespaceClosureRunNoIPV6(t *testing.T) {
 		leasesFilePath: dhclientLeasesFilePathDefault,
 		pidFilePath:    dhclientPIDFilePathDefault,
 	}
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, dhclient, deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "")
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, dhclient, deviceName, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false)
+	assert.NoError(t, err)
+	assert.NotNil(t, closure)
+	err = closure.run(mockNetNS)
+	assert.NoError(t, err)
+}
+
+func TestSetupNamespaceClosureRunBlockIMDS(t *testing.T) {
+	ctrl, _, _, _, mockNetLink, mockExec, _ := setup(t)
+	defer ctrl.Finish()
+
+	mockCmd := mock_execwrapper.NewMockCmd(ctrl)
+	mockNetNS := mock_ns.NewMockNetNS(ctrl)
+	mockENILink := mock_netlink.NewMockLink(ctrl)
+	ipv4Address := &netlink.Addr{}
+	ipv6Address := &netlink.Addr{}
+	eniLinkIndex := 1
+	_, imdsNetwork, err := net.ParseCIDR(instanceMetadataEndpoint)
+	assert.NoError(t, err)
+	gomock.InOrder(
+		mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(ipv4Address, nil),
+		mockNetLink.EXPECT().ParseAddr(eniIPV6CIDRBlock).Return(ipv6Address, nil),
+		mockNetLink.EXPECT().LinkByName(deviceName).Return(mockENILink, nil),
+		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(nil),
+		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv6Address).Return(nil),
+		mockNetLink.EXPECT().LinkSetUp(mockENILink).Return(nil),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
+			assert.Nil(t, route.Gw)
+			assert.Equal(t, imdsNetwork.String(), route.Dst.String())
+			assert.Equal(t, syscall.RTN_BLACKHOLE, route.Type)
+		}).Return(nil),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
+			assert.Equal(t, route.Gw.String(), eniIPV4Gateway)
+		}).Return(nil),
+		mockExec.EXPECT().Command(dhclientExecutableNameDefault,
+			"-q",
+			"-lf",
+			dhclientLeasesFilePathDefault+"/ns-"+deviceName+"-dhclient4.leases",
+			"-pf",
+			dhclientPIDFilePathDefault+"/ns-"+deviceName+"-dhclient4.pid",
+			"eth1").Return(mockCmd),
+		mockCmd.EXPECT().CombinedOutput().Return([]byte{0}, nil),
+		mockENILink.EXPECT().Attrs().Return(&netlink.LinkAttrs{Index: eniLinkIndex}),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
+			assert.Equal(t, route.Gw.String(), eniIPV6Gateway)
+			assert.Equal(t, route.LinkIndex, eniLinkIndex)
+		}).Return(nil),
+		mockExec.EXPECT().Command(dhclientExecutableNameDefault,
+			"-q",
+			"-6",
+			"-lf",
+			dhclientLeasesFilePathDefault+"/ns-"+deviceName+"-dhclient6.leases",
+			"-pf",
+			dhclientPIDFilePathDefault+"/ns-"+deviceName+"-dhclient6.pid",
+			"eth1").Return(mockCmd),
+		mockCmd.EXPECT().CombinedOutput().Return([]byte{0}, nil),
+	)
+	dhclient := &dhclient{
+		exec:           mockExec,
+		executable:     dhclientExecutableNameDefault,
+		leasesFilePath: dhclientLeasesFilePathDefault,
+		pidFilePath:    dhclientPIDFilePathDefault,
+	}
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, dhclient, deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, true)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -1189,7 +1279,7 @@ func TestSetupNamespaceClosureRun(t *testing.T) {
 		leasesFilePath: dhclientLeasesFilePathDefault,
 		pidFilePath:    dhclientPIDFilePathDefault,
 	}
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, dhclient, deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, dhclient, deviceName, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)

--- a/plugins/eni/engine/mocks/engine_mocks.go
+++ b/plugins/eni/engine/mocks/engine_mocks.go
@@ -133,14 +133,14 @@ func (_mr *_MockEngineRecorder) GetMACAddressOfENI(arg0, arg1 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetMACAddressOfENI", arg0, arg1)
 }
 
-func (_m *MockEngine) SetupContainerNamespace(_param0 string, _param1 string, _param2 string, _param3 string, _param4 string, _param5 string, _param6 engine.DHClient) error {
-	ret := _m.ctrl.Call(_m, "SetupContainerNamespace", _param0, _param1, _param2, _param3, _param4, _param5, _param6)
+func (_m *MockEngine) SetupContainerNamespace(_param0 string, _param1 string, _param2 string, _param3 string, _param4 string, _param5 string, _param6 engine.DHClient, _param7 bool) error {
+	ret := _m.ctrl.Call(_m, "SetupContainerNamespace", _param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockEngineRecorder) SetupContainerNamespace(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetupContainerNamespace", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+func (_mr *_MockEngineRecorder) SetupContainerNamespace(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetupContainerNamespace", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 func (_m *MockEngine) TeardownContainerNamespace(_param0 string, _param1 string, _param2 bool, _param3 engine.DHClient) error {

--- a/plugins/eni/types/types.go
+++ b/plugins/eni/types/types.go
@@ -31,6 +31,7 @@ type NetConf struct {
 	IPV4Address string `json:"ipv4-address"`
 	MACAddress  string `json:"mac"`
 	IPV6Address string `json:"ipv6-address"`
+	BlockIMDS   bool   `json:"block-instance-metadata"`
 }
 
 // NewConf creates a new NetConf object by parsing the arguments supplied


### PR DESCRIPTION
### Details
ENI plugin adds a `blackhole` route to `169.254.169.254` if `block-instance-metadata` config  parameter is set to `true`

From [README](https://github.com/aaithal/amazon-ecs-cni-plugins-1/blob/06af3daac1437a016e62ca959cb31a3acce81014/plugins/eni/README.md):
```
{
    "type":"ecs-eni",
    "cniVersion":"0.3.0",
    "eni":"eni-eni01en1",
    "ipv4-address":"172.31.31.65/20",
    "mac":"01:23:45:67:89:ab",
    "block-instance-metadata":true
}
```

### Testing Done
Verified that new updated tests pass:
* [X] unit tests
* [X] integration tests
* [X] end-to-end tests
* [X] manual tests: Manually verified that a container started using this plugin cannot access instance metadata service
```
$ ip netns exec 314e45c385dd ip route
default via xxx dev eth1
...
blackhole 169.254.169.254
169.254.170.2 via 169.254.172.1 dev ecs-eth0

$ ip netns exec 314e45c385dd curl 169.254.169.254
curl: (7) Couldn't connect to server
```