### PR TITLE
Skip IPAM del when IPAM isn't specified in the configuration

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,48 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"reflect"
+)
+
+// ZeroOrNil checks if the passed in interface is empty
+func ZeroOrNil(obj interface{}) bool {
+	if obj == nil {
+		return true
+	}
+
+	// IsValid returns false if value is the zero Value
+	value := reflect.ValueOf(obj)
+	if !value.IsValid() {
+		return true
+	}
+
+	// For array, slice, map check if the length is 0
+	switch value.Kind() {
+	case reflect.Slice, reflect.Array, reflect.Map:
+		return value.Len() == 0
+	}
+
+	if !value.Type().Comparable() {
+		return false
+	}
+
+	// Create the zero valued the type and compare
+	zero := reflect.Zero(reflect.TypeOf(obj))
+	if obj == zero.Interface() {
+		return true
+	}
+	return false
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,55 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestZeroOrNil(t *testing.T) {
+	type ZeroTest struct {
+		testInt int
+		TestStr string
+	}
+
+	var strMap map[string]string
+
+	testCases := []struct {
+		param    interface{}
+		expected bool
+		name     string
+	}{
+		{nil, true, "Nil is nil"},
+		{0, true, "0 is 0"},
+		{"", true, "\"\" is the string zerovalue"},
+		{ZeroTest{}, true, "ZeroTest zero-value should be zero"},
+		{ZeroTest{TestStr: "asdf"}, false, "ZeroTest with a field populated isn't zero"},
+		{1, false, "1 is not 0"},
+		{[]uint16{1, 2, 3}, false, "[1,2,3] is not zero"},
+		{[]uint16{}, true, "[] is zero"},
+		{struct{ uncomparable []uint16 }{uncomparable: []uint16{1, 2, 3}}, false, "Uncomparable structs are never zero"},
+		{struct{ uncomparable []uint16 }{uncomparable: nil}, false, "Uncomparable structs are never zero"},
+		{strMap, true, "map[string]string is zero or nil"},
+		{make(map[string]string), true, "empty map[string]string is zero or nil"},
+		{map[string]string{"foo": "bar"}, false, "map[string]string{foo:bar} is not zero or nil"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, ZeroOrNil(tc.param), tc.name)
+		})
+	}
+}

--- a/plugins/ecs-bridge/commands/commands.go
+++ b/plugins/ecs-bridge/commands/commands.go
@@ -14,8 +14,10 @@
 package commands
 
 import (
+	"github.com/aws/amazon-ecs-cni-plugins/pkg/utils"
 	"github.com/aws/amazon-ecs-cni-plugins/plugins/ecs-bridge/engine"
 	"github.com/aws/amazon-ecs-cni-plugins/plugins/ecs-bridge/types"
+
 	log "github.com/cihub/seelog"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types/current"
@@ -110,6 +112,11 @@ func del(args *skel.CmdArgs, engine engine.Engine) error {
 		// Either should be sufficient.
 		log.Errorf("Error loading config from args: %v", err)
 		return err
+	}
+
+	if utils.ZeroOrNil(conf.IPAM) {
+		log.Infof("IPAM configuration not found, skip DEL for IPAM")
+		return nil
 	}
 
 	log.Infof("Running IPAM plugin DEL: %s", conf.IPAM.Type)

--- a/plugins/ipam/config/config.go
+++ b/plugins/ipam/config/config.go
@@ -64,7 +64,7 @@ func LoadIPAMConfig(bytes []byte, args string) (*IPAMConfig, string, error) {
 		return nil, "", errors.Wrapf(err, "loadIPAMConfig config: failed to load netconf, %s", string(bytes))
 	}
 	if ipamConf.IPAM == nil {
-		return nil, "", errors.New("loadIPAMConfig config: 'IPAM' field missing in configuration")
+		return nil, "", errors.New("loadIPAMConfig config: 'IPAM' field missing in configuration: " + string(bytes))
 	}
 
 	// subnet is required to allocate ip address


### PR DESCRIPTION
This PR will suppress the error caused by calling the bridge plugin without specifying the `ipam` plugin. This kind of behavior happens in ecs-agent: aws/amazon-ecs-agent#976