### PR TITLE
IPv6 fixes

### DIFF
--- a/plugins/eni/engine/dhclient_test.go
+++ b/plugins/eni/engine/dhclient_test.go
@@ -65,7 +65,8 @@ func TestLoadEnvConfig(t *testing.T) {
 				os.Unsetenv(dhclientPIDFilePathEnvConfig)
 			}()
 
-			dhclient := newDHClient(oswrapper.NewOS(), nil, nil)
+			dhclient := newDHClient(oswrapper.NewOS(), nil, nil,
+				maxDHClientStartAttempts, durationBetweenDHClientStartRetries)
 			assert.Equal(t, tc.expecedExecutable, dhclient.executable)
 			assert.Equal(t, tc.expectedLeasesFilePath, dhclient.leasesFilePath)
 			assert.Equal(t, tc.expectedPIDFilePath, dhclient.pidFilePath)
@@ -83,7 +84,8 @@ func TestIsDHClientInPathReturnsFalseOnLookPathError(t *testing.T) {
 		mockOS.EXPECT().Getenv(dhclientPIDFilePathEnvConfig).Return(""),
 		mockExec.EXPECT().LookPath(dhclientExecutableNameDefault).Return("", errors.New("error")),
 	)
-	dhclient := newDHClient(mockOS, mockExec, mockIOUtil)
+	dhclient := newDHClient(mockOS, mockExec, mockIOUtil,
+		maxDHClientStartAttempts, durationBetweenDHClientStartRetries)
 
 	ok := dhclient.IsExecutableInPath()
 	assert.False(t, ok)
@@ -99,7 +101,8 @@ func TestIsDHClientInPath(t *testing.T) {
 		mockOS.EXPECT().Getenv(dhclientPIDFilePathEnvConfig).Return(""),
 		mockExec.EXPECT().LookPath(dhclientExecutableNameDefault).Return("dhclient", nil),
 	)
-	dhclient := newDHClient(mockOS, mockExec, mockIOUtil)
+	dhclient := newDHClient(mockOS, mockExec, mockIOUtil,
+		maxDHClientStartAttempts, durationBetweenDHClientStartRetries)
 
 	ok := dhclient.IsExecutableInPath()
 	assert.True(t, ok)
@@ -115,7 +118,8 @@ func TestGetDHClientArgs(t *testing.T) {
 		mockOS.EXPECT().Getenv(dhclientPIDFilePathEnvConfig).Return(""),
 	)
 
-	dhclient := newDHClient(mockOS, mockExec, mockIOUtil)
+	dhclient := newDHClient(mockOS, mockExec, mockIOUtil,
+		maxDHClientStartAttempts, durationBetweenDHClientStartRetries)
 	testCases := []struct {
 		ipRev        int
 		expectedArgs []string
@@ -161,7 +165,8 @@ func TestGetLeasesAndPIDFile(t *testing.T) {
 		mockOS.EXPECT().Getenv(dhclientPIDFilePathEnvConfig).Return(""),
 	)
 
-	dhclient := newDHClient(mockOS, mockExec, mockIOUtil)
+	dhclient := newDHClient(mockOS, mockExec, mockIOUtil,
+		maxDHClientStartAttempts, durationBetweenDHClientStartRetries)
 	testCases := []struct {
 		ipRev              int
 		expectedLeasesFile string
@@ -356,7 +361,8 @@ func TestStopDHClientFailsWhenReadFileReturnsError(t *testing.T) {
 		mockIOUtil.EXPECT().ReadFile(pidFilePath).Return(nil, errors.New("error")),
 	)
 
-	dhclient := newDHClient(mockOS, mockExec, mockIOUtil)
+	dhclient := newDHClient(mockOS, mockExec, mockIOUtil,
+		maxDHClientStartAttempts, durationBetweenDHClientStartRetries)
 
 	err := dhclient.Stop(deviceName, ipRev4, checkDHClientStateInteval, maxDHClientStopWait)
 	assert.Error(t, err)

--- a/plugins/eni/engine/nsclosure.go
+++ b/plugins/eni/engine/nsclosure.go
@@ -193,10 +193,7 @@ func (closureContext *setupNamespaceClosureContext) run(_ ns.NetNS) error {
 		}
 
 		// Start dhclient for IPV6 address
-		err = closureContext.dhclient.Start(closureContext.deviceName, ipRev6)
-		if err != nil {
-			return err
-		}
+		return closureContext.dhclient.Start(closureContext.deviceName, ipRev6)
 	}
 
 	return nil


### PR DESCRIPTION
### Description
Benchmarking experiments show that there's usually 3-6s delay in
IPv6 address path being populated in Instance Metadata for ENI.

We also need to take into account delays in cleaning up of the
dhclient processes running in the default network namespace.

This commit adds retries for both of these to account for these
delays. This will result in a latency increase in surfacing errors
when there are failures such as wrong MAC Address being specified
in the CNI config. However, we err on the side of correctness,
fault tolerance and caution, and deem that as an acceptable cost.

### Testing Done
- [X] Build and Tests
```
$ make clean plugins unit-test integration-test e2e-test; echo $?
0
```
- [X] Manual Testing: Ran the plugin manually and verified that the container was configured with IPv6 IP address