### PR TITLE
eni: ignore 'file exists' for default ipv6 route

### DIFF
--- a/plugins/eni/engine/engine.go
+++ b/plugins/eni/engine/engine.go
@@ -253,7 +253,8 @@ func (engine *engine) getIPV6GatewayIPFromRoutes(link netlink.Link,
 	// its routing table for non-primary ENIs attached to the instance. Retry querying
 	// the routing table for such scenarios.
 	for numTicks := 0; numTicks < maxTicks; numTicks++ {
-		log.Infof("Trying to get IPV6 Gateway from route table, attempt: %d/%d", numTicks+1, maxTicks)
+		log.Infof("Trying to get IPV6 Gateway from route table (device=%s), attempt: %d/%d",
+			deviceName, numTicks+1, maxTicks)
 		gateway, ok, err := engine.getIPV6GatewayIPFromRoutesOnce(link, deviceName)
 		if err != nil {
 			return "", err
@@ -286,7 +287,7 @@ func (engine *engine) getIPV6GatewayIPFromRoutesOnce(link netlink.Link, deviceNa
 		if (route.Dst == nil || route.Dst.String() == zeroLengthIPString) && // Dst is not set
 			route.Src.String() == zeroLengthIPString && // Src is not set
 			route.Gw.String() != zeroLengthIPString { // Gw is set
-			log.Debugf("Found ipv6 gateway: %s", route.Gw.String())
+			log.Debugf("Found ipv6 gateway (device=%s): %s", deviceName, route.Gw.String())
 			return route.Gw.String(), true, nil
 		}
 	}


### PR DESCRIPTION
Since the default ipv6 gateway can also be configured based on the
ipv6 address when the address is assigned, we sometimes get the
"file exists" error when adding the default route for the ipv6
gateway. This change ignores that error.

There are also logging improvements to log either the eni id or the
device name in various log messages for the eni plugin.

- [X] Build and Tests
```
$ make clean plugins unit-test integration-test e2e-test; echo $?
0
```
- [X] Manual Testing: Task start errors on an Instance with ipv6 enabled reduced to 0% from 40-60% with the modified eni plugin