### PR TITLE
Adding retry for eni plugin to acquire mac address

### DIFF
--- a/pkg/utils/backoff.go
+++ b/pkg/utils/backoff.go
@@ -1,0 +1,83 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"math"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// Backoff defines the interface for a backoff
+type Backoff interface {
+	Reset()
+	Duration() time.Duration
+}
+
+// SimpleBackoff implements a simple mechanism for backoff
+type SimpleBackoff struct {
+	current        time.Duration
+	start          time.Duration
+	max            time.Duration
+	jitterMultiple float64
+	multiple       float64
+	mu             sync.Mutex
+}
+
+// NewSimpleBackoff creates a Backoff which ranges from min to max increasing by
+// multiple each time.
+// It also adds (and yes, the jitter is always added, never
+// subtracted) a random amount of jitter up to jitterMultiple percent (that is,
+// jitterMultiple = 0.0 is no jitter, 0.15 is 15% added jitter). The total time
+// may exceed "max" when accounting for jitter, such that the absolute max is
+// max + max * jiterMultiple
+func NewSimpleBackoff(min, max time.Duration, jitterMultiple, multiple float64) *SimpleBackoff {
+	return &SimpleBackoff{
+		start:          min,
+		current:        min,
+		max:            max,
+		jitterMultiple: jitterMultiple,
+		multiple:       multiple,
+	}
+}
+
+// Duration returns the time a backoff should wait
+func (sb *SimpleBackoff) Duration() time.Duration {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	ret := sb.current
+	sb.current = time.Duration(math.Min(float64(sb.max.Nanoseconds()), float64(float64(sb.current.Nanoseconds())*sb.multiple)))
+
+	return AddJitter(ret, time.Duration(int64(float64(ret)*sb.jitterMultiple)))
+}
+
+// Reset sets backoff to its initial status
+func (sb *SimpleBackoff) Reset() {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	sb.current = sb.start
+}
+
+// AddJitter adds an amount of jitter between 0 and the given jitter to the
+// given duration
+func AddJitter(duration time.Duration, jitter time.Duration) time.Duration {
+	var randJitter int64
+	if jitter.Nanoseconds() == 0 {
+		randJitter = 0
+	} else {
+		randJitter = rand.Int63n(jitter.Nanoseconds())
+	}
+	return time.Duration(duration.Nanoseconds() + randJitter)
+}

--- a/pkg/utils/backoff_test.go
+++ b/pkg/utils/backoff_test.go
@@ -1,0 +1,51 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSimpleBackoff(t *testing.T) {
+	sb := NewSimpleBackoff(10*time.Second, time.Minute, 0, 2)
+
+	for i := 0; i < 2; i++ {
+		duration := sb.Duration()
+		if duration.Nanoseconds() != 10*time.Second.Nanoseconds() {
+			t.Error("Initial duration incorrect. Got ", duration.Nanoseconds())
+		}
+
+		duration = sb.Duration()
+		if duration.Nanoseconds() != 20*time.Second.Nanoseconds() {
+			t.Error("Increase incorrect")
+		}
+		_ = sb.Duration() // 40s
+		duration = sb.Duration()
+		if duration.Nanoseconds() != 60*time.Second.Nanoseconds() {
+			t.Error("Didn't stop at maximum")
+		}
+		sb.Reset()
+		// loop to redo the above tests after resetting, they should be the same
+	}
+}
+
+func TestJitter(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		duration := AddJitter(10*time.Second, 3*time.Second)
+		if duration < 10*time.Second || duration > 13*time.Second {
+			t.Error("Excessive amount of jitter", duration)
+		}
+	}
+}

--- a/pkg/utils/errors.go
+++ b/pkg/utils/errors.go
@@ -1,0 +1,56 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+// Retriable definies the interface for retriable object
+type Retriable interface {
+	Retry() bool
+}
+
+// DefaultRetriable is a simple struct that implements the Retriable
+type DefaultRetriable struct {
+	retry bool
+}
+
+// Retry returns whether should retry or not
+func (dr DefaultRetriable) Retry() bool {
+	return dr.retry
+}
+
+// NewRetriable creates a simple Retriable object
+func NewRetriable(retry bool) Retriable {
+	return DefaultRetriable{
+		retry: retry,
+	}
+}
+
+// RetriableError definies the interface for retriable error
+type RetriableError interface {
+	Retriable
+	error
+}
+
+// DefaultRetriableError is a simple struct that implements the RetriableError
+type DefaultRetriableError struct {
+	Retriable
+	error
+}
+
+// NewRetriableError creates a simple RetriableError object
+func NewRetriableError(retriable Retriable, err error) RetriableError {
+	return &DefaultRetriableError{
+		retriable,
+		err,
+	}
+}

--- a/plugins/eni/engine/dhclient_test.go
+++ b/plugins/eni/engine/dhclient_test.go
@@ -246,7 +246,7 @@ func TestWaitForStopWaitsForDuration(t *testing.T) {
 		mockDHClientProcess.EXPECT().Signal(syscall.Signal(0)).Return(nil),
 		mockDHClientProcess.EXPECT().Signal(syscall.Signal(0)).Do(func(_ syscall.Signal) {
 			cancel()
-		}).Return(nil),
+		}).Return(nil).MaxTimes(2),
 	)
 
 	err := dhclient.waitForProcesToFinish(ctx, cancel, time.Microsecond, mockDHClientProcess)

--- a/plugins/eni/engine/engine.go
+++ b/plugins/eni/engine/engine.go
@@ -143,7 +143,7 @@ func (engine *engine) GetMACAddressOfENI(macAddresses []string, eniID string) (s
 		}
 	}
 
-	return "", newUnmappedMACAddressError("getMACAddressOfENI", "engine",
+	return "", NewUnmappedMACAddressError("getMACAddressOfENI", "engine",
 		fmt.Sprintf("mac address of ENI '%s' not found", eniID))
 }
 

--- a/plugins/eni/engine/engine_test.go
+++ b/plugins/eni/engine/engine_test.go
@@ -120,7 +120,7 @@ func TestGetMACAddressOfENIReturnsErrorOnGetMetadataError(t *testing.T) {
 
 	_, err := engine.GetMACAddressOfENI([]string{firstMACAddress}, firstENIID)
 	assert.Error(t, err)
-	_, ok := err.(*unmappedMACAddressError)
+	_, ok := err.(*UnmappedMACAddressError)
 	assert.True(t, ok)
 }
 
@@ -133,7 +133,7 @@ func TestGetMACAddressOfENIReturnsErrorWhenNotFound(t *testing.T) {
 
 	_, err := engine.GetMACAddressOfENI([]string{firstMACAddress}, secondENIID)
 	assert.Error(t, err)
-	_, ok := err.(*unmappedMACAddressError)
+	_, ok := err.(*UnmappedMACAddressError)
 	assert.True(t, ok)
 }
 

--- a/plugins/eni/engine/error.go
+++ b/plugins/eni/engine/error.go
@@ -21,23 +21,35 @@ type _error struct {
 	message   string
 }
 
+// Error returns user friendly description of the error
 func (err *_error) Error() string {
 	return err.operation + " " + err.origin + ": " + err.message
 }
 
-// unmappedMACAddressError is used to indicate that the MAC address of the ENI
+// IsUnmappedMACAddressError defines the interface representing the error UnmappedMACAddressError
+type IsUnmappedMACAddressError interface {
+	IsUnmappedMACAddressError() bool
+}
+
+// UnmappedMACAddressError is used to indicate that the MAC address of the ENI
 // cannot be mapped to any of the network interfaces attached to the host as
 // determined by the instance metadata
-type unmappedMACAddressError struct {
+type UnmappedMACAddressError struct {
 	err *_error
 }
 
-func (macErr *unmappedMACAddressError) Error() string {
+func (macErr *UnmappedMACAddressError) Error() string {
 	return macErr.err.Error()
 }
 
-func newUnmappedMACAddressError(operation string, origin string, message string) error {
-	return &unmappedMACAddressError{
+// IsUnmappedMACAddressError returns whether the error is UnmappedMACAddressError
+func (macErr *UnmappedMACAddressError) IsUnmappedMACAddressError() bool {
+	return true
+}
+
+// NewUnmappedMACAddressError creates the error UnmappedMACAddressError
+func NewUnmappedMACAddressError(operation string, origin string, message string) error {
+	return &UnmappedMACAddressError{
 		err: &_error{
 			operation: operation,
 			origin:    origin,


### PR DESCRIPTION
This PR adds backoff retry logic for retrieving mac address of the eni from ec2 instance metadata.