### PR TITLE
Increase the timeout for ec2 instance metadata

### DIFF
--- a/plugins/eni/commands/commands.go
+++ b/plugins/eni/commands/commands.go
@@ -35,7 +35,7 @@ const (
 	ec2InstanceMetadataBackoffMax      = 1 * time.Second
 	ec2InstanceMetadataBackoffMultiple = 2
 	ec2InstanceMetadataBackoffJitter   = 0.2
-	ec2InstanceMetadataTimeout         = 5 * time.Second
+	ec2InstanceMetadataTimeout         = 30 * time.Second
 )
 
 var (


### PR DESCRIPTION
5 seconds seems too low for eni information to be available in ec2 instance metadata. Sometimes this could be as long as 18 seconds. Increase this to 30 seconds for safe.