### PR TITLE
Add a route for arp query request from host

### DIFF
--- a/plugins/ecs-bridge/engine/engine_test.go
+++ b/plugins/ecs-bridge/engine/engine_test.go
@@ -375,11 +375,20 @@ func TestConfigureContainerVethInterfaceConfigureIfaceError(t *testing.T) {
 	ctrl, _, mockNetLink, mockIP, mockIPAM, _ := setup(t)
 	defer ctrl.Finish()
 
-	result := &current.Result{}
+	ip, ipnet, err := net.ParseCIDR("10.0.0.1/22")
+	assert.NoError(t, err)
+	result := &current.Result{
+		IPs: []*current.IPConfig{
+			{
+				Address: *ipnet,
+				Gateway: ip,
+			},
+		},
+	}
 	mockIPAM.EXPECT().ConfigureIface(interfaceName, result).Return(errors.New("error"))
 	configContext := newConfigureVethContext(
 		interfaceName, result, mockIP, mockIPAM, mockNetLink)
-	err := configContext.run(nil)
+	err = configContext.run(nil)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
This PR is trying to fix issue: aws/amazon-ecs-agent#1230 by adding a route for the arp query from host,
After adding this, the route inside the container will look like:
```
root@797087bca637:/# ip route
default via 172.31.192.1 dev eth0
169.254.170.2 via 169.254.172.1 dev ecs-eth0
169.254.172.1 via 169.254.172.1 dev ecs-eth0
172.31.192.0/20 dev eth0  proto kernel  scope link  src 172.31.198.99
```

The issue can be reproduced without this change but not with this change  by the following steps:
* inside container: curl 169.254.170.2/v2/metadata
* inside container: arp -a
* host: sudo arp -d 169.254.172.2
* inside container: curl  --connection-timeout 5 169.254.170.2/v2/metadata  (this will timeout without the change)