### PR TITLE
Use 8 character git short sha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GO_EXECUTABLE=$(shell command -v go 2> /dev/null)
 # these details from the environment in order support builds outside
 # of a git working copy. If they're not given explicitly, we'll try to
 # use git to directly inspect the repository state...
-GIT_SHORT_HASH ?= $(shell git rev-parse --short HEAD 2> /dev/null)
+GIT_SHORT_HASH ?= $(shell git rev-parse --short=8 HEAD 2> /dev/null)
 GIT_PORCELAIN ?= $(shell git status --porcelain 2> /dev/null | wc -l)
 
 # ...and if we can't inspect the repo state, we'll fall back to some


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Use 8 character short sha in the Makefile.

This change was suggested in https://github.com/aws/amazon-ecs-agent/pull/1287

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->yes
