### PR TITLE
eni: add ipv4 subnet gateway from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2018.06.1-dev 
+* Enhancement - Reduced the ENI plugin execution time by removing the 
+  dependency on instance metadata service (by adding the `subnetgateway-ipv4-address`
+  config flag)
+ 
 ## 2018.02.0
 * Bug - Fixed an issue where container wasn't able to talk to agent endpoint.
 [#73](https://github.com/aws/amazon-ecs-cni-plugins/pull/73)

--- a/pkg/utils/gateway.go
+++ b/pkg/utils/gateway.go
@@ -1,0 +1,116 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	minIPV4CIDRBlockSize = 28
+	maxIPV4CIDRBlockSize = 16
+)
+
+// ParseIPV4GatewayNetmaskError is used to indicate any error with parsing the
+// IPV4 address and the netmask of the ENI
+type ParseIPV4GatewayNetmaskError struct {
+	operation string
+	origin    string
+	message   string
+}
+
+func (err *ParseIPV4GatewayNetmaskError) Error() string {
+	return err.operation + " " + err.origin + ": " + err.message
+}
+
+func newParseIPV4GatewayNetmaskError(operation string, origin string, message string) error {
+	return &ParseIPV4GatewayNetmaskError{
+		operation: operation,
+		origin:    origin,
+		message:   message,
+	}
+}
+
+// ComputeIPV4GatewayNetmask computes the subnet gateway and netmask for
+// the gateway given the ipv4 cidr block for the ENI
+// Gateways are provided in VPC subnets at base +1
+// (NOTE: from the base of the subnet, not the VPC base)
+// https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Subnets.html#vpc-sizing-ipv4
+func ComputeIPV4GatewayNetmask(cidrBlock string) (string, string, error) {
+	// The IPV4 CIDR block is of the format ip-addr/netmask
+	ip, ipNet, err := net.ParseCIDR(cidrBlock)
+	if err != nil {
+		return "", "", errors.Wrapf(err,
+			"compute ipv4 gateway netmask: unable to parse cidr: '%s'", cidrBlock)
+	}
+
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return "", "", newParseIPV4GatewayNetmaskError("compute ipv4 gateway netmask", "engine",
+			fmt.Sprintf("unable to parse ipv4 gateway from cidr block '%s'", cidrBlock))
+	}
+
+	maskOnes, _ := ipNet.Mask.Size()
+	// As per
+	// http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Subnets.html#VPC_Sizing
+	// You can assign a single CIDR block to a VPC. The allowed block size
+	// is between a /16 netmask and /28 netmask. Verify that
+	if maskOnes > minIPV4CIDRBlockSize {
+		return "", "", errors.Errorf("compute ipv4 gateway netmask: invalid ipv4 cidr block, %d > 28", maskOnes)
+	}
+	if maskOnes < maxIPV4CIDRBlockSize {
+		return "", "", errors.Errorf("compute ipv4 gateway netmask: invalid ipv4 cidr block, %d <= 16", maskOnes)
+	}
+
+	// ipv4 gateway is the first available IP address in the subnet
+	ip4[3] = ip4[3] + 1
+	return ip4.String(), fmt.Sprintf("%d", maskOnes), nil
+}
+
+// ParseIPV4GatewayNetmask parses the cidr block to return the subnet gateway
+// ip and the netmask. There's no additional computation here. It essentially
+// splits the string on '/' and returns the parts. However, it uses golang's
+// 'net' package to do this. It also performs additional validation of the
+// cidr block, which is typically passed to the plugin as a config
+func ParseIPV4GatewayNetmask(cidrBlock string) (string, string, error) {
+	// The IPV4 CIDR block is of the format ip-addr/netmask
+	ip, ipNet, err := net.ParseCIDR(cidrBlock)
+	if err != nil {
+		return "", "", errors.Wrapf(err,
+			"parse ipv4 gateway netmask: unable to parse ipv4 subnet gateway from config: '%s'", cidrBlock)
+	}
+
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return "", "", errors.Errorf("parse ipv4 gateway netmask: unable to parse ipv4 gateway from config: '%s'",
+			cidrBlock)
+	}
+
+	maskOnes, _ := ipNet.Mask.Size()
+	// As per
+	// http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Subnets.html#VPC_Sizing
+	// You can assign a single CIDR block to a VPC. The allowed block size
+	// is between a /16 netmask and /28 netmask. Verify that
+	if maskOnes > minIPV4CIDRBlockSize {
+		return "", "", errors.Errorf("parse ipv4 gateway netmask: invalid ipv4 cidr block, %d > 28", maskOnes)
+	}
+	if maskOnes < maxIPV4CIDRBlockSize {
+		return "", "", errors.Errorf("parse ipv4 gateway netmask: invalid ipv4 cidr block, %d <= 16", maskOnes)
+	}
+
+	return ip4.String(), fmt.Sprintf("%d", maskOnes), nil
+}

--- a/pkg/utils/gateway_test.go
+++ b/pkg/utils/gateway_test.go
@@ -1,0 +1,91 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeGatewayReturnsErrorOnMalformedCIDR(t *testing.T) {
+	_, _, err := ComputeIPV4GatewayNetmask("1.1.1.1")
+	assert.Error(t, err)
+}
+
+func TestComputeGatewayReturnsErrorOnMalformedNetmaskInCIDR(t *testing.T) {
+	_, _, err := ComputeIPV4GatewayNetmask("1.1.1.1/")
+	assert.Error(t, err)
+}
+
+func TestComputeGatewayReturnsErrorOnMalformedCIDRBlockInCIDR(t *testing.T) {
+	_, _, err := ComputeIPV4GatewayNetmask("1.1.1/1")
+	assert.Error(t, err)
+}
+
+func TestComputeGatewayReturnsErrorOnEmptyRouterInCIDR(t *testing.T) {
+	_, _, err := ComputeIPV4GatewayNetmask("1.1.1./1")
+	assert.Error(t, err)
+}
+
+func TestComputeGatewayReturnsErrorOnInvalidRouterInCIDR(t *testing.T) {
+	_, _, err := ComputeIPV4GatewayNetmask("1.1.1.foo/1")
+	assert.Error(t, err)
+}
+
+func TestComputeGatewayReturnsErrorOnInvalidCIDRBlock(t *testing.T) {
+	_, _, err := ComputeIPV4GatewayNetmask("10.0.64.0/29")
+	assert.Error(t, err)
+	_, _, err = ComputeIPV4GatewayNetmask("10.0.64.0/15")
+	assert.Error(t, err)
+}
+
+func TestComputeGateway(t *testing.T) {
+	gateway, netmask, err := ComputeIPV4GatewayNetmask("10.0.1.64/26")
+	assert.NoError(t, err)
+	assert.Equal(t, gateway, "10.0.1.65")
+	assert.Equal(t, netmask, "26")
+}
+
+func TestParseGatewayReturnsErrorOnMalformedCIDR(t *testing.T) {
+	_, _, err := ParseIPV4GatewayNetmask("1.1.1.1")
+	assert.Error(t, err)
+}
+
+func TestParseGatewayReturnsErrorOnMalformedNetmaskInCIDR(t *testing.T) {
+	_, _, err := ParseIPV4GatewayNetmask("1.1.1.1/")
+	assert.Error(t, err)
+}
+
+func TestParseGatewayReturnsErrorOnMalformedCIDRBlockInCIDR(t *testing.T) {
+	_, _, err := ParseIPV4GatewayNetmask("1.1.1/1")
+	assert.Error(t, err)
+}
+
+func TesParseGatewayReturnsErrorOnEmptyRouterInCIDR(t *testing.T) {
+	_, _, err := ParseIPV4GatewayNetmask("1.1.1./1")
+	assert.Error(t, err)
+}
+
+func TestParseGatewayReturnsErrorOnInvalidRouterInCIDR(t *testing.T) {
+	_, _, err := ParseIPV4GatewayNetmask("1.1.1.foo/1")
+	assert.Error(t, err)
+}
+
+func TestParseGateway(t *testing.T) {
+	gateway, netmask, err := ParseIPV4GatewayNetmask("10.0.1.64/26")
+	assert.NoError(t, err)
+	assert.Equal(t, gateway, "10.0.1.64")
+	assert.Equal(t, netmask, "26")
+}

--- a/plugins/eni/README.md
+++ b/plugins/eni/README.md
@@ -25,6 +25,7 @@ Primary private IPV4 address of the interface
 * `ipv6-address` (string, optional): the ipv6 address of the ENI
 * `block-instance-metadata` (bool, optional): specifies if the route to EC2 
 instance metadata should be blocked
+* `subnetgateway-ipv4-address` (string, optional): specifies the ipv4 address, with the CIDR block for the subnet gateway. Example: `10.15.145.128/25`
 
 ## Environment Variables
 * `ENI_DHCLIENT_LEASES_PATH` (string, optional): the dhclient leases file path.

--- a/plugins/eni/engine/error.go
+++ b/plugins/eni/engine/error.go
@@ -57,23 +57,3 @@ func NewUnmappedMACAddressError(operation string, origin string, message string)
 		},
 	}
 }
-
-// parseIPV4GatewayNetmaskError is used to indicate any error with parsing the
-// IPV4 address and the netmask of the ENI
-type parseIPV4GatewayNetmaskError struct {
-	err *_error
-}
-
-func (parseErr *parseIPV4GatewayNetmaskError) Error() string {
-	return parseErr.err.Error()
-}
-
-func newParseIPV4GatewayNetmaskError(operation string, origin string, message string) error {
-	return &parseIPV4GatewayNetmaskError{
-		err: &_error{
-			operation: operation,
-			origin:    origin,
-			message:   message,
-		},
-	}
-}

--- a/plugins/eni/types/types.go
+++ b/plugins/eni/types/types.go
@@ -27,11 +27,12 @@ import (
 // with an ENI
 type NetConf struct {
 	types.NetConf
-	ENIID       string `json:"eni"`
-	IPV4Address string `json:"ipv4-address"`
-	MACAddress  string `json:"mac"`
-	IPV6Address string `json:"ipv6-address"`
-	BlockIMDS   bool   `json:"block-instance-metadata"`
+	ENIID                    string `json:"eni"`
+	IPV4Address              string `json:"ipv4-address"`
+	MACAddress               string `json:"mac"`
+	IPV6Address              string `json:"ipv6-address"`
+	BlockIMDS                bool   `json:"block-instance-metadata"`
+	SubnetGatewayIPV4Address string `json:"subnetgateway-ipv4-address"`
 }
 
 // NewConf creates a new NetConf object by parsing the arguments supplied


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Add functionality to parse ipv4 subnet gateway from config. This eliminates the dependency on instance metadata service for the ENI plugin, which should hopefully reduce the ENI setup time.

### Implementation details
<!-- How are the changes implemented? -->

Added a new config field for supplying ipv4 subnet gateway address for
the caller. When that's specified the plugin can use that directly
instead of looking up that information from instance metadata service.

Also, got rid of the check where the plugin makes sure that the eni id
and the mac address match by looking up instance metadata. This leads to
addtional delays starting the plugin while adding very little value to
the functionality. Hence, the ENI plugin doesn't do that check anymore.
It's left to the caller instead should make sure that correct values
are passed to the plugin, which the ECS agent is currently doing anyway.

### Testing
<!-- How was this tested? -->

New tests cover the changes: Yes

| Description | End-to-end test duration for setting up the ENI (Average of 5 runs) | 
|------------ |:-----------------------------------------------:|
| With instance metadata interaction | 1278 ms |
| Without instance metadata interaction | 142.5 ms |


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->

Added a changelog commit

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
