### PR TITLE
Fix race condition when create/configure the bridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ unit-test: $(SOURCES)
 integration-test: $(SOURCE)
 	go test -v -tags integration -race -timeout 10s ./pkg/... ./plugins/...
 
+sudo-integration-test: $(SOURCE)
+	sudo -E ${GO_EXECUTABLE} test -v -tags "sudo integration" -race -timeout 10s ./plugins/...
+
 e2e-test:  $(SOURCE) plugins
 	sudo -E CNI_PATH=${ROOT}/bin/plugins ${GO_EXECUTABLE} test -v -tags e2e -race -timeout 120s ./plugins/...
 

--- a/plugins/ecs-bridge/commands/commands.go
+++ b/plugins/ecs-bridge/commands/commands.go
@@ -27,21 +27,28 @@ import (
 // connect container's namespace with the bridge
 func Add(args *skel.CmdArgs) error {
 	defer log.Flush()
-	return add(args, engine.New())
+	err := add(args, engine.New())
+	if err != nil {
+		log.Errorf("Error executing ADD command: %v", err)
+	}
+
+	return err
 }
 
 // Del invokes the command to tear down the bridge and the veth pair
 func Del(args *skel.CmdArgs) error {
 	defer log.Flush()
-	return del(args, engine.New())
+	err := del(args, engine.New())
+	if err != nil {
+		log.Errorf("Error executing DEL command: %v", err)
+	}
+
+	return err
 }
 
 func add(args *skel.CmdArgs, engine engine.Engine) error {
 	conf, err := types.NewConf(args)
 	if err != nil {
-		// TODO: We log and return errors throughout this function.
-		// Either should be sufficient.
-		log.Errorf("Error loading config from args: %v", err)
 		return err
 	}
 
@@ -108,9 +115,6 @@ func add(args *skel.CmdArgs, engine engine.Engine) error {
 func del(args *skel.CmdArgs, engine engine.Engine) error {
 	conf, err := types.NewConf(args)
 	if err != nil {
-		// TODO: We log and return errors throughout this function.
-		// Either should be sufficient.
-		log.Errorf("Error loading config from args: %v", err)
 		return err
 	}
 

--- a/plugins/ecs-bridge/engine/engine_integ_test.go
+++ b/plugins/ecs-bridge/engine/engine_integ_test.go
@@ -1,0 +1,104 @@
+// +build sudo,integration
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"github.com/aws/amazon-ecs-cni-plugins/pkg/netlinkwrapper"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"net"
+	"os"
+	"testing"
+)
+
+const (
+	testBridgeName    = "test-ecs-bridge"
+	testMTU           = 1500
+	testGatewayIPCIDR = "172.31.0.1"
+	testdb            = "/tmp/__boltdb_test"
+)
+
+func cleanup(t *testing.T) {
+	_, err := os.Stat(testdb)
+	if err != nil {
+		require.True(t, os.IsNotExist(err), "if it's not file not exist error, then there should be a problem: %v", err)
+	} else {
+		err = os.Remove(testdb)
+		require.NoError(t, err, "Remove the existed db should not cause error")
+	}
+
+	// clean up the test bridge, if it's created
+	testBridge, err := netlink.LinkByName(testBridgeName)
+	if err == nil {
+		err = netlink.LinkDel(testBridge)
+		assert.NoError(t, err)
+	}
+}
+
+func TestCreateBridgeAlreadyExists(t *testing.T) {
+	defer cleanup(t)
+
+	testEngine := &engine{
+		netLink: netlinkwrapper.NewNetLink(),
+	}
+	err := testEngine.createBridge(testBridgeName, testMTU)
+	require.NoError(t, err)
+
+	// try creating the bridge again, expect getting a "file exists" error
+	err = testEngine.createBridge(testBridgeName, testMTU)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), fileExistsErrMsg)
+}
+
+func TestConfigureBridgeNetworkAlreadyExists(t *testing.T) {
+	defer cleanup(t)
+
+	gatewayIPAddr := net.ParseIP(testGatewayIPCIDR)
+
+	testEngine := &engine{
+		netLink: netlinkwrapper.NewNetLink(),
+	}
+
+	ipConfig := &current.IPConfig{
+		Address: net.IPNet{
+			Mask: net.CIDRMask(31, 32),
+		},
+		Gateway: gatewayIPAddr,
+	}
+
+	result := &current.Result{
+		IPs: []*current.IPConfig{ipConfig},
+	}
+
+	// create and configure a bridge
+	testBridge, err := testEngine.CreateBridge(testBridgeName, testMTU)
+	require.NoError(t, err)
+
+	err = testEngine.ConfigureBridge(result, testBridge)
+	require.NoError(t, err)
+
+	// check that we get a "file exists" error when trying to assign same address to the bridge
+	err = netlink.AddrAdd(testBridge, &netlink.Addr{
+		IPNet: &net.IPNet{
+			IP:   result.IPs[0].Gateway,
+			Mask: result.IPs[0].Address.Mask,
+		},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), fileExistsErrMsg)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Due to the fact that multiple tasks may be modifying the bridge at the same time, there are race conditions when creating/configuring the bridge, which cause the following error:
```
# create bridge race
unable to configure pause container namespace: cni setup: invoke bridge plugin failed: bridge create: unable to add bridge interface ecs-bridge: file exists

# configure bridge race
unable to configure pause container namespace: cni setup: invoke bridge plugin failed: bridge configure: unable to assign ip address to bridge ecs-bridge: file exists
```
This PR fixes the two race conditions.

### Implementation details
<!-- How are the changes implemented? -->
When creating the bridge, check whether the bridge exists after failing to create it.
When assigning ip address to the bridge, check whether the ip address is already assigned after failing to assign it.

### Testing
<!-- How was this tested? -->
Unit tests added. Following targets passed:
make unit-test
make integration-test
make e2e-test
make plugins

Manually tested by building this into an agent and ran awsvpc tasks, verified that race condition failure not happening with the fix.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
