### PR TITLE
Add option to set interface MTU in eni plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2019.10.0
+* Enhancement - Add `MTU` field into ENI config. [#95](https://github.com/aws/amazon-ecs-cni-plugins/pull/95)
+
 ## 2019.09.0
 * Enhancement - Add `stay-down` config to ENI plugin. [#94](https://github.com/aws/amazon-ecs-cni-plugins/pull/94)
 

--- a/pkg/netlinkwrapper/mocks/netlinkwrapper_mocks.go
+++ b/pkg/netlinkwrapper/mocks/netlinkwrapper_mocks.go
@@ -134,6 +134,20 @@ func (mr *MockNetLinkMockRecorder) LinkSetDown(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSetDown", reflect.TypeOf((*MockNetLink)(nil).LinkSetDown), arg0)
 }
 
+// LinkSetMTU mocks base method
+func (m *MockNetLink) LinkSetMTU(arg0 netlink.Link, arg1 int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LinkSetMTU", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LinkSetMTU indicates an expected call of LinkSetMTU
+func (mr *MockNetLinkMockRecorder) LinkSetMTU(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSetMTU", reflect.TypeOf((*MockNetLink)(nil).LinkSetMTU), arg0, arg1)
+}
+
 // LinkSetMaster mocks base method
 func (m *MockNetLink) LinkSetMaster(arg0 netlink.Link, arg1 *netlink.Bridge) error {
 	m.ctrl.T.Helper()

--- a/pkg/netlinkwrapper/netlink.go
+++ b/pkg/netlinkwrapper/netlink.go
@@ -35,6 +35,8 @@ type NetLink interface {
 	LinkSetName(link netlink.Link, name string) error
 	// LinkSetUp is equivalent to `ip link set $link up`
 	LinkSetUp(link netlink.Link) error
+	// LinkSetMTU is equivalent to `ip link set $link mtu $mtu`
+	LinkSetMTU(link netlink.Link, mtu int) error
 	// LinkList is equivalent to: `ip link show`
 	LinkList() ([]netlink.Link, error)
 	// LinkSetDown is equivalent to: `ip link set $link down`
@@ -83,6 +85,10 @@ func (*netLink) LinkSetUp(link netlink.Link) error {
 
 func (*netLink) LinkSetName(link netlink.Link, name string) error {
 	return netlink.LinkSetName(link, name)
+}
+
+func (*netLink) LinkSetMTU(link netlink.Link, mtu int) error {
+	return netlink.LinkSetMTU(link, mtu)
 }
 
 func (*netLink) LinkList() ([]netlink.Link, error) {

--- a/plugins/eni/commands/commands.go
+++ b/plugins/eni/commands/commands.go
@@ -147,7 +147,7 @@ func add(args *skel.CmdArgs, engine engine.Engine) error {
 	// do the same
 	err = engine.SetupContainerNamespace(args, networkDeviceName, macAddressOfENI,
 		fmt.Sprintf("%s/%s", conf.IPV4Address, ipv4Netmask),
-		ipv6Address, ipv4Gateway, ipv6Gateway, conf.BlockIMDS, conf.StayDown)
+		ipv6Address, ipv4Gateway, ipv6Gateway, conf.BlockIMDS, conf.StayDown, conf.MTU)
 	if err != nil {
 		log.Errorf("Unable to setup container's namespace (device name=%s): %v", networkDeviceName, err)
 		return err

--- a/plugins/eni/commands/commands_test.go
+++ b/plugins/eni/commands/commands_test.go
@@ -187,7 +187,7 @@ func TestAddSetupContainerNamespaceFails(t *testing.T) {
 		mockEngine.EXPECT().GetIPV6PrefixLength(macAddress).Return(eniIPV6SubnetMask, nil),
 		mockEngine.EXPECT().GetIPV6Gateway(deviceName).Return(eniIPV6Gateway, nil),
 		mockEngine.EXPECT().SetupContainerNamespace(gomock.Any(), deviceName, macAddress, eniIPV4AddressWithSubnetMask,
-			eniIPV6AddressWithSubnetMask, eniIPV4Gateway, eniIPV6Gateway, false, false).Return(errors.New("error")),
+			eniIPV6AddressWithSubnetMask, eniIPV4Gateway, eniIPV6Gateway, false, false, 0).Return(errors.New("error")),
 	)
 
 	err := add(eniArgs, mockEngine)
@@ -203,7 +203,7 @@ func TestAddSetupContainerNamespaceFailsNoIPV6(t *testing.T) {
 		mockEngine.EXPECT().GetInterfaceDeviceName(macAddress).Return(deviceName, nil),
 		mockEngine.EXPECT().GetIPV4GatewayNetmask(macAddress).Return(eniIPV4Gateway, eniIPV4SubnetMask, nil),
 		mockEngine.EXPECT().SetupContainerNamespace(gomock.Any(), deviceName, macAddress, eniIPV4AddressWithSubnetMask, "",
-			eniIPV4Gateway, "", false, false).Return(errors.New("error")),
+			eniIPV4Gateway, "", false, false, 0).Return(errors.New("error")),
 	)
 
 	err := add(eniArgsNoIPV6, mockEngine)
@@ -219,7 +219,7 @@ func TestAddSubnetGatewayInConfig(t *testing.T) {
 		mockEngine.EXPECT().GetInterfaceDeviceName(macAddress).Return(deviceName, nil),
 		mockEngine.EXPECT().SetupContainerNamespace(gomock.Any(), deviceName, macAddress,
 			eniIPV4AddressWithSubnetMask, "",
-			eniIPV4Gateway, "", false, false).Return(nil),
+			eniIPV4Gateway, "", false, false, 0).Return(nil),
 	)
 
 	err := add(eniArgsSubnetGateway, mockEngine)
@@ -237,7 +237,7 @@ func TestAddNoError(t *testing.T) {
 		mockEngine.EXPECT().GetIPV6PrefixLength(macAddress).Return(eniIPV6SubnetMask, nil),
 		mockEngine.EXPECT().GetIPV6Gateway(deviceName).Return(eniIPV6Gateway, nil),
 		mockEngine.EXPECT().SetupContainerNamespace(gomock.Any(), deviceName, macAddress, eniIPV4AddressWithSubnetMask,
-			eniIPV6AddressWithSubnetMask, eniIPV4Gateway, eniIPV6Gateway, false, false).Return(nil),
+			eniIPV6AddressWithSubnetMask, eniIPV4Gateway, eniIPV6Gateway, false, false, 0).Return(nil),
 	)
 
 	err := add(eniArgs, mockEngine)
@@ -255,7 +255,7 @@ func TestAddStayDownNoError(t *testing.T) {
 		mockEngine.EXPECT().GetIPV6PrefixLength(macAddress).Return(eniIPV6SubnetMask, nil),
 		mockEngine.EXPECT().GetIPV6Gateway(deviceName).Return(eniIPV6Gateway, nil),
 		mockEngine.EXPECT().SetupContainerNamespace(gomock.Any(), deviceName, macAddress, eniIPV4AddressWithSubnetMask,
-			eniIPV6AddressWithSubnetMask, eniIPV4Gateway, eniIPV6Gateway, false, true).Return(nil),
+			eniIPV6AddressWithSubnetMask, eniIPV4Gateway, eniIPV6Gateway, false, true, 0).Return(nil),
 	)
 
 	err := add(eniArgsStayDown, mockEngine)
@@ -271,7 +271,7 @@ func TestAddNoErrorWhenIPV6AddressNotSpecifiedInConfig(t *testing.T) {
 		mockEngine.EXPECT().GetInterfaceDeviceName(macAddress).Return(deviceName, nil),
 		mockEngine.EXPECT().GetIPV4GatewayNetmask(macAddress).Return(eniIPV4Gateway, eniIPV4SubnetMask, nil),
 		mockEngine.EXPECT().SetupContainerNamespace(gomock.Any(), deviceName, macAddress, eniIPV4AddressWithSubnetMask, "",
-			eniIPV4Gateway, "", false, false).Return(nil),
+			eniIPV4Gateway, "", false, false, 0).Return(nil),
 	)
 
 	err := add(eniArgsNoIPV6, mockEngine)
@@ -299,7 +299,7 @@ func TestAddPrintResult(t *testing.T) {
 		mockEngine.EXPECT().GetIPV6PrefixLength(macAddress).Return(eniIPV6SubnetMask, nil),
 		mockEngine.EXPECT().GetIPV6Gateway(deviceName).Return(eniIPV6Gateway, nil),
 		mockEngine.EXPECT().SetupContainerNamespace(gomock.Any(), deviceName, macAddress, eniIPV4AddressWithSubnetMask,
-			eniIPV6AddressWithSubnetMask, eniIPV4Gateway, eniIPV6Gateway, false, false).Return(nil),
+			eniIPV6AddressWithSubnetMask, eniIPV4Gateway, eniIPV6Gateway, false, false, 0).Return(nil),
 	)
 
 	oldStdout := os.Stdout
@@ -342,7 +342,7 @@ func TestAddPrintResultNoIPV6(t *testing.T) {
 		mockEngine.EXPECT().GetInterfaceDeviceName(macAddress).Return(deviceName, nil),
 		mockEngine.EXPECT().GetIPV4GatewayNetmask(macAddress).Return(eniIPV4Gateway, eniIPV4SubnetMask, nil),
 		mockEngine.EXPECT().SetupContainerNamespace(gomock.Any(), deviceName, macAddress, eniIPV4AddressWithSubnetMask, "",
-			eniIPV4Gateway, "", false, false).Return(nil),
+			eniIPV4Gateway, "", false, false, 0).Return(nil),
 	)
 
 	oldStdout := os.Stdout

--- a/plugins/eni/engine/engine.go
+++ b/plugins/eni/engine/engine.go
@@ -64,7 +64,7 @@ type Engine interface {
 	SetupContainerNamespace(args *skel.CmdArgs, deviceName string, macAddress string,
 		ipv4Address string, ipv6Address string,
 		ipv4Gateway string, ipv6Gateway string,
-		blockIMDS bool, stayDown bool) error
+		blockIMDS bool, stayDown bool, mtu int) error
 	TeardownContainerNamespace(netns string, macAddress string) error
 }
 
@@ -320,7 +320,8 @@ func (engine *engine) SetupContainerNamespace(args *skel.CmdArgs,
 	ipv4Gateway string,
 	ipv6Gateway string,
 	blockIMDS bool,
-	stayDown bool) error {
+	stayDown bool,
+	mtu int) error {
 	// Get the device link for the ENI
 	eniLink, err := engine.netLink.LinkByName(deviceName)
 	if err != nil {
@@ -348,7 +349,7 @@ func (engine *engine) SetupContainerNamespace(args *skel.CmdArgs,
 	}
 	// Generate the closure to execute within the container's namespace
 	toRun, err := newSetupNamespaceClosureContext(engine.netLink, args.IfName, deviceName, macAddress,
-		ipv4Address, ipv6Address, ipv4Gateway, ipv6Gateway, blockIMDS)
+		ipv4Address, ipv6Address, ipv4Gateway, ipv6Gateway, blockIMDS, mtu)
 	if err != nil {
 		return errors.Wrap(err,
 			"setupContainerNamespace engine: unable to create closure to execute in container namespace")

--- a/plugins/eni/engine/engine_test.go
+++ b/plugins/eni/engine/engine_test.go
@@ -670,7 +670,7 @@ func TestSetupContainerNamespaceFailsOnLinkByNameError(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, false)
+	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, false, 0)
 	assert.Error(t, err)
 }
 
@@ -687,7 +687,7 @@ func TestSetupContainerNamespaceFailsOnGetNSError(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, false)
+	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, false, 0)
 	assert.Error(t, err)
 }
 
@@ -708,7 +708,7 @@ func TestSetupContainerNamespaceFailsOnLinksetNsFdError(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, false)
+	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, false, 0)
 	assert.Error(t, err)
 }
 
@@ -730,7 +730,7 @@ func TestSetupContainerNamespaceFailsOnParseAddrError(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, false)
+	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, false, 0)
 	assert.Error(t, err)
 }
 
@@ -754,7 +754,7 @@ func TestSetupContainerNamespaceFailsOnWithNetNSPathError(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, false)
+	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, false, 0)
 	assert.Error(t, err)
 }
 
@@ -778,7 +778,7 @@ func TestSetupContainerNamespaceNoIPV6(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, false)
+	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, false, 0)
 	assert.NoError(t, err)
 }
 
@@ -804,7 +804,7 @@ func TestSetupContainerNamespace(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, false)
+	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, false, 0)
 	assert.NoError(t, err)
 }
 
@@ -825,7 +825,7 @@ func TestSetupContainerNamespaceStayDown(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, true)
+	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, true, 0)
 	assert.NoError(t, err)
 }
 
@@ -834,7 +834,7 @@ func TestSetupNamespaceClosureCreationFailsOnIPV4ParseAddrError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(nil, errors.New("error"))
-	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false)
+	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, 0)
 	assert.Error(t, err)
 }
 
@@ -845,7 +845,7 @@ func TestSetupNamespaceClosureCreationFailsOnIPV4ParseGatewayError(t *testing.T)
 	ipv4Addr := &netlink.Addr{}
 	mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(ipv4Addr, nil)
 	// Gateway is an empty string, so we expect this method to fail
-	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", "", "", false)
+	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", "", "", false, 0)
 	assert.Error(t, err)
 }
 
@@ -858,7 +858,7 @@ func TestSetupNamespaceClosureCreationFailsOnIPV6ParseAddrError(t *testing.T) {
 		mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(ipv4Addr, nil),
 		mockNetLink.EXPECT().ParseAddr(eniIPV6CIDRBlock).Return(nil, errors.New("error")),
 	)
-	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false)
+	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, 0)
 	assert.Error(t, err)
 }
 
@@ -873,7 +873,7 @@ func TestSetupNamespaceClosureCreationFailsOnIPV6ParseGatewayError(t *testing.T)
 		mockNetLink.EXPECT().ParseAddr(eniIPV6CIDRBlock).Return(ipv6Addr, nil),
 	)
 	// Gateway is an empty string, so we expect this method to fail
-	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, "", false)
+	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, "", false, 0)
 	assert.Error(t, err)
 }
 
@@ -887,7 +887,7 @@ func TestSetupNamespaceClosureRunFailsOnLinkByNameError(t *testing.T) {
 		mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(ipv4Addr, nil),
 		mockNetLink.EXPECT().LinkByName(deviceName).Return(nil, errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -907,7 +907,7 @@ func TestSetupNamespaceClosureRunFailsOnIPV4AddrAddError(t *testing.T) {
 		mockNetLink.EXPECT().LinkSetName(mockENILink, "eth0").Return(nil),
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -930,7 +930,7 @@ func TestSetupNamespaceClosureRunFailsOnIPV6AddrAddError(t *testing.T) {
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(nil),
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv6Address).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -951,7 +951,7 @@ func TestSetupNamespaceClosureRunFailsOnLinkSetupError(t *testing.T) {
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(nil),
 		mockNetLink.EXPECT().LinkSetUp(mockENILink).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -979,7 +979,7 @@ func TestSetupNamespaceClosureRunFailsOnBlackholeRouteAddError(t *testing.T) {
 			assert.Equal(t, syscall.RTN_BLACKHOLE, route.Type)
 		}).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", true)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", true, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -1003,7 +1003,7 @@ func TestSetupNamespaceClosureRunFailsOnIPV4RouteAddError(t *testing.T) {
 			assert.Equal(t, route.Gw.String(), eniIPV4Gateway)
 		}).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -1036,7 +1036,7 @@ func TestSetupNamespaceClosureRunFailsOnIPV6RouteAddError(t *testing.T) {
 			assert.Equal(t, route.LinkIndex, eniLinkIndex)
 		}).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -1074,7 +1074,7 @@ func TestSetupNamespaceClosureRunNoIPV6(t *testing.T) {
 			assert.Equal(t, route.Gw.String(), eniIPV4Gateway)
 		}).Return(nil),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -1114,7 +1114,7 @@ func TestSetupNamespaceClosureRunBlockIMDS(t *testing.T) {
 			assert.Equal(t, route.LinkIndex, eniLinkIndex)
 		}).Return(nil),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, true)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, true, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -1147,7 +1147,7 @@ func TestSetupNamespaceClosureRun(t *testing.T) {
 			assert.Equal(t, route.LinkIndex, eniLinkIndex)
 		}).Return(nil),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -1206,5 +1206,40 @@ func TestGetLinkByHardwareAddress(t *testing.T) {
 	)
 
 	_, err = getLinkByHardwareAddress(mockNetLink, eth1Address)
+	assert.NoError(t, err)
+}
+
+func TestSetupNamespaceClosureRunWithMTU(t *testing.T) {
+	ctrl, _, _, mockNetLink := setup(t)
+	defer ctrl.Finish()
+
+	mockNetNS := mock_ns.NewMockNetNS(ctrl)
+	mockENILink := mock_netlink.NewMockLink(ctrl)
+
+	ipv4Address := &netlink.Addr{}
+	ipv6Address := &netlink.Addr{}
+	eniLinkIndex := 1
+	gomock.InOrder(
+		mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(ipv4Address, nil),
+		mockNetLink.EXPECT().ParseAddr(eniIPV6CIDRBlock).Return(ipv6Address, nil),
+		mockNetLink.EXPECT().LinkByName(deviceName).Return(mockENILink, nil),
+		mockNetLink.EXPECT().LinkSetName(mockENILink, "eth0").Return(nil),
+		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(nil),
+		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv6Address).Return(nil),
+		mockNetLink.EXPECT().LinkSetUp(mockENILink).Return(nil),
+		mockNetLink.EXPECT().LinkSetMTU(mockENILink, 9001).Return(nil),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
+			assert.Equal(t, route.Gw.String(), eniIPV4Gateway)
+		}).Return(nil),
+		mockENILink.EXPECT().Attrs().Return(&netlink.LinkAttrs{Index: eniLinkIndex}),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
+			assert.Equal(t, route.Gw.String(), eniIPV6Gateway)
+			assert.Equal(t, route.LinkIndex, eniLinkIndex)
+		}).Return(nil),
+	)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, 9001)
+	assert.NoError(t, err)
+	assert.NotNil(t, closure)
+	err = closure.run(mockNetNS)
 	assert.NoError(t, err)
 }

--- a/plugins/eni/engine/mocks/engine_mocks.go
+++ b/plugins/eni/engine/mocks/engine_mocks.go
@@ -169,17 +169,17 @@ func (mr *MockEngineMockRecorder) GetMACAddressOfENI(arg0, arg1 interface{}) *go
 }
 
 // SetupContainerNamespace mocks base method
-func (m *MockEngine) SetupContainerNamespace(arg0 *skel.CmdArgs, arg1, arg2, arg3, arg4, arg5, arg6 string, arg7, arg8 bool) error {
+func (m *MockEngine) SetupContainerNamespace(arg0 *skel.CmdArgs, arg1, arg2, arg3, arg4, arg5, arg6 string, arg7, arg8 bool, arg9 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetupContainerNamespace", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	ret := m.ctrl.Call(m, "SetupContainerNamespace", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetupContainerNamespace indicates an expected call of SetupContainerNamespace
-func (mr *MockEngineMockRecorder) SetupContainerNamespace(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
+func (mr *MockEngineMockRecorder) SetupContainerNamespace(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupContainerNamespace", reflect.TypeOf((*MockEngine)(nil).SetupContainerNamespace), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupContainerNamespace", reflect.TypeOf((*MockEngine)(nil).SetupContainerNamespace), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 }
 
 // TeardownContainerNamespace mocks base method

--- a/plugins/eni/types/types.go
+++ b/plugins/eni/types/types.go
@@ -34,6 +34,7 @@ type NetConf struct {
 	BlockIMDS                bool   `json:"block-instance-metadata"`
 	SubnetGatewayIPV4Address string `json:"subnetgateway-ipv4-address"`
 	StayDown                 bool   `json:"stay-down"`
+	MTU                      int    `json:"mtu"`
 }
 
 // NewConf creates a new NetConf object by parsing the arguments supplied


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add option to set the eni MTU 
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
```
make unit-test
integration-test
sudo-integration-test
e2e-test
```

New tests cover the changes: <!-- yes|no -->
yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
* Enhancement - Add `MTU` config to ENI plugin

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
yes
