### PR TITLE
ecs-eni: Support multiple IP (v4 and v6) addresses per interface

### DIFF
--- a/plugins/eni/engine/engine.go
+++ b/plugins/eni/engine/engine.go
@@ -62,8 +62,7 @@ type Engine interface {
 	DoesMACAddressMapToIPV4Address(macAddress string, ipv4Address string) (bool, error)
 	DoesMACAddressMapToIPV6Address(macAddress string, ipv4Address string) (bool, error)
 	SetupContainerNamespace(args *skel.CmdArgs, deviceName string, macAddress string,
-		ipv4Address string, ipv6Address string,
-		ipv4Gateway string, ipv6Gateway string,
+		ipAddresses []string, gatewayAddresses []string,
 		blockIMDS bool, stayDown bool, mtu int) error
 	TeardownContainerNamespace(netns string, macAddress string) error
 }
@@ -315,10 +314,8 @@ func (engine *engine) doesMACAddressMapToIPAddress(macAddress string, addressToF
 func (engine *engine) SetupContainerNamespace(args *skel.CmdArgs,
 	deviceName string,
 	macAddress string,
-	ipv4Address string,
-	ipv6Address string,
-	ipv4Gateway string,
-	ipv6Gateway string,
+	ipAddresses []string,
+	gatewayAddresses []string,
 	blockIMDS bool,
 	stayDown bool,
 	mtu int) error {
@@ -347,9 +344,10 @@ func (engine *engine) SetupContainerNamespace(args *skel.CmdArgs,
 		// The 'stay-down' config is set. No need to configure anything else.
 		return nil
 	}
+
 	// Generate the closure to execute within the container's namespace
 	toRun, err := newSetupNamespaceClosureContext(engine.netLink, args.IfName, deviceName, macAddress,
-		ipv4Address, ipv6Address, ipv4Gateway, ipv6Gateway, blockIMDS, mtu)
+		ipAddresses, gatewayAddresses, blockIMDS, mtu)
 	if err != nil {
 		return errors.Wrap(err,
 			"setupContainerNamespace engine: unable to create closure to execute in container namespace")

--- a/plugins/eni/engine/engine_test.go
+++ b/plugins/eni/engine/engine_test.go
@@ -670,7 +670,7 @@ func TestSetupContainerNamespaceFailsOnLinkByNameError(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, false, 0)
+	}, deviceName, eniMACAddress, []string{eniIPV4CIDRBlock, eniIPV6CIDRBlock}, []string{eniIPV4Gateway, eniIPV6Gateway}, false, false, 0)
 	assert.Error(t, err)
 }
 
@@ -687,7 +687,7 @@ func TestSetupContainerNamespaceFailsOnGetNSError(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, false, 0)
+	}, deviceName, eniMACAddress, []string{eniIPV4CIDRBlock, eniIPV6CIDRBlock}, []string{eniIPV4Gateway, eniIPV6Gateway}, false, false, 0)
 	assert.Error(t, err)
 }
 
@@ -708,7 +708,7 @@ func TestSetupContainerNamespaceFailsOnLinksetNsFdError(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, false, 0)
+	}, deviceName, eniMACAddress, []string{eniIPV4CIDRBlock, eniIPV6CIDRBlock}, []string{eniIPV4Gateway, eniIPV6Gateway}, false, false, 0)
 	assert.Error(t, err)
 }
 
@@ -730,7 +730,7 @@ func TestSetupContainerNamespaceFailsOnParseAddrError(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, false, 0)
+	}, deviceName, eniMACAddress, []string{eniIPV4CIDRBlock, eniIPV6CIDRBlock}, []string{eniIPV4Gateway, eniIPV6Gateway}, false, false, 0)
 	assert.Error(t, err)
 }
 
@@ -754,7 +754,7 @@ func TestSetupContainerNamespaceFailsOnWithNetNSPathError(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, false, 0)
+	}, deviceName, eniMACAddress, []string{eniIPV4CIDRBlock}, []string{eniIPV4Gateway}, false, false, 0)
 	assert.Error(t, err)
 }
 
@@ -778,7 +778,7 @@ func TestSetupContainerNamespaceNoIPV6(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, false, 0)
+	}, deviceName, eniMACAddress, []string{eniIPV4CIDRBlock}, []string{eniIPV4Gateway}, false, false, 0)
 	assert.NoError(t, err)
 }
 
@@ -804,7 +804,7 @@ func TestSetupContainerNamespace(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, false, 0)
+	}, deviceName, eniMACAddress, []string{eniIPV4CIDRBlock, eniIPV6CIDRBlock}, []string{eniIPV4Gateway, eniIPV6Gateway}, false, false, 0)
 	assert.NoError(t, err)
 }
 
@@ -825,7 +825,7 @@ func TestSetupContainerNamespaceStayDown(t *testing.T) {
 	err := engine.SetupContainerNamespace(&skel.CmdArgs{
 		Netns:  "ns1",
 		IfName: "eth0",
-	}, deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, true, 0)
+	}, deviceName, eniMACAddress, []string{eniIPV4CIDRBlock, eniIPV6CIDRBlock}, []string{eniIPV4Gateway, eniIPV6Gateway}, false, true, 0)
 	assert.NoError(t, err)
 }
 
@@ -834,7 +834,8 @@ func TestSetupNamespaceClosureCreationFailsOnIPV4ParseAddrError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(nil, errors.New("error"))
-	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, 0)
+	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress,
+		[]string{eniIPV4CIDRBlock}, []string{eniIPV4Gateway}, false, 0)
 	assert.Error(t, err)
 }
 
@@ -845,7 +846,8 @@ func TestSetupNamespaceClosureCreationFailsOnIPV4ParseGatewayError(t *testing.T)
 	ipv4Addr := &netlink.Addr{}
 	mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(ipv4Addr, nil)
 	// Gateway is an empty string, so we expect this method to fail
-	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", "", "", false, 0)
+	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress,
+		[]string{eniIPV4CIDRBlock}, []string{""}, false, 0)
 	assert.Error(t, err)
 }
 
@@ -858,7 +860,8 @@ func TestSetupNamespaceClosureCreationFailsOnIPV6ParseAddrError(t *testing.T) {
 		mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(ipv4Addr, nil),
 		mockNetLink.EXPECT().ParseAddr(eniIPV6CIDRBlock).Return(nil, errors.New("error")),
 	)
-	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, 0)
+	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress,
+		[]string{eniIPV4CIDRBlock, eniIPV6CIDRBlock}, []string{eniIPV4Gateway, eniIPV6Gateway}, false, 0)
 	assert.Error(t, err)
 }
 
@@ -873,7 +876,8 @@ func TestSetupNamespaceClosureCreationFailsOnIPV6ParseGatewayError(t *testing.T)
 		mockNetLink.EXPECT().ParseAddr(eniIPV6CIDRBlock).Return(ipv6Addr, nil),
 	)
 	// Gateway is an empty string, so we expect this method to fail
-	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, "", false, 0)
+	_, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress,
+		[]string{eniIPV4CIDRBlock, eniIPV6CIDRBlock}, []string{eniIPV4Gateway, ""}, false, 0)
 	assert.Error(t, err)
 }
 
@@ -887,7 +891,8 @@ func TestSetupNamespaceClosureRunFailsOnLinkByNameError(t *testing.T) {
 		mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(ipv4Addr, nil),
 		mockNetLink.EXPECT().LinkByName(deviceName).Return(nil, errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, 0)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress,
+		[]string{eniIPV4CIDRBlock}, []string{eniIPV4Gateway}, false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -907,7 +912,8 @@ func TestSetupNamespaceClosureRunFailsOnIPV4AddrAddError(t *testing.T) {
 		mockNetLink.EXPECT().LinkSetName(mockENILink, "eth0").Return(nil),
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, 0)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress,
+		[]string{eniIPV4CIDRBlock}, []string{eniIPV4Gateway}, false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -930,7 +936,8 @@ func TestSetupNamespaceClosureRunFailsOnIPV6AddrAddError(t *testing.T) {
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(nil),
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv6Address).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, 0)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress,
+		[]string{eniIPV4CIDRBlock, eniIPV6CIDRBlock}, []string{eniIPV4Gateway, eniIPV6Gateway}, false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -951,7 +958,8 @@ func TestSetupNamespaceClosureRunFailsOnLinkSetupError(t *testing.T) {
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(nil),
 		mockNetLink.EXPECT().LinkSetUp(mockENILink).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, 0)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress,
+		[]string{eniIPV4CIDRBlock}, []string{eniIPV4Gateway}, false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -979,7 +987,8 @@ func TestSetupNamespaceClosureRunFailsOnBlackholeRouteAddError(t *testing.T) {
 			assert.Equal(t, syscall.RTN_BLACKHOLE, route.Type)
 		}).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", true, 0)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress,
+		[]string{eniIPV4CIDRBlock}, []string{eniIPV4Gateway}, true, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -993,17 +1002,20 @@ func TestSetupNamespaceClosureRunFailsOnIPV4RouteAddError(t *testing.T) {
 	mockNetNS := mock_ns.NewMockNetNS(ctrl)
 	mockENILink := mock_netlink.NewMockLink(ctrl)
 	ipv4Address := &netlink.Addr{}
+	eniLinkIndex := 1
 	gomock.InOrder(
 		mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(ipv4Address, nil),
 		mockNetLink.EXPECT().LinkByName(deviceName).Return(mockENILink, nil),
 		mockNetLink.EXPECT().LinkSetName(mockENILink, "eth0").Return(nil),
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(nil),
 		mockNetLink.EXPECT().LinkSetUp(mockENILink).Return(nil),
+		mockENILink.EXPECT().Attrs().Return(&netlink.LinkAttrs{Index: eniLinkIndex}),
 		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
 			assert.Equal(t, route.Gw.String(), eniIPV4Gateway)
 		}).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, 0)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress,
+		[]string{eniIPV4CIDRBlock}, []string{eniIPV4Gateway}, false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -1027,6 +1039,7 @@ func TestSetupNamespaceClosureRunFailsOnIPV6RouteAddError(t *testing.T) {
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(nil),
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv6Address).Return(nil),
 		mockNetLink.EXPECT().LinkSetUp(mockENILink).Return(nil),
+		mockENILink.EXPECT().Attrs().Return(&netlink.LinkAttrs{Index: eniLinkIndex}),
 		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
 			assert.Equal(t, route.Gw.String(), eniIPV4Gateway)
 		}).Return(nil),
@@ -1036,7 +1049,8 @@ func TestSetupNamespaceClosureRunFailsOnIPV6RouteAddError(t *testing.T) {
 			assert.Equal(t, route.LinkIndex, eniLinkIndex)
 		}).Return(errors.New("error")),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, 0)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress,
+		[]string{eniIPV4CIDRBlock, eniIPV6CIDRBlock}, []string{eniIPV4Gateway, eniIPV6Gateway}, false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -1064,17 +1078,20 @@ func TestSetupNamespaceClosureRunNoIPV6(t *testing.T) {
 	mockNetNS := mock_ns.NewMockNetNS(ctrl)
 	mockENILink := mock_netlink.NewMockLink(ctrl)
 	ipv4Address := &netlink.Addr{}
+	eniLinkIndex := 1
 	gomock.InOrder(
 		mockNetLink.EXPECT().ParseAddr(eniIPV4CIDRBlock).Return(ipv4Address, nil),
 		mockNetLink.EXPECT().LinkByName(deviceName).Return(mockENILink, nil),
 		mockNetLink.EXPECT().LinkSetName(mockENILink, "eth0").Return(nil),
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(nil),
 		mockNetLink.EXPECT().LinkSetUp(mockENILink).Return(nil),
+		mockENILink.EXPECT().Attrs().Return(&netlink.LinkAttrs{Index: eniLinkIndex}),
 		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
 			assert.Equal(t, route.Gw.String(), eniIPV4Gateway)
 		}).Return(nil),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, "", eniIPV4Gateway, "", false, 0)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress,
+		[]string{eniIPV4CIDRBlock}, []string{eniIPV4Gateway}, false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -1105,6 +1122,7 @@ func TestSetupNamespaceClosureRunBlockIMDS(t *testing.T) {
 			assert.Equal(t, imdsNetwork.String(), route.Dst.String())
 			assert.Equal(t, syscall.RTN_BLACKHOLE, route.Type)
 		}).Return(nil),
+		mockENILink.EXPECT().Attrs().Return(&netlink.LinkAttrs{Index: eniLinkIndex}),
 		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
 			assert.Equal(t, route.Gw.String(), eniIPV4Gateway)
 		}).Return(nil),
@@ -1114,7 +1132,8 @@ func TestSetupNamespaceClosureRunBlockIMDS(t *testing.T) {
 			assert.Equal(t, route.LinkIndex, eniLinkIndex)
 		}).Return(nil),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, true, 0)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress,
+		[]string{eniIPV4CIDRBlock, eniIPV6CIDRBlock}, []string{eniIPV4Gateway, eniIPV6Gateway}, true, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -1138,6 +1157,7 @@ func TestSetupNamespaceClosureRun(t *testing.T) {
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv4Address).Return(nil),
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv6Address).Return(nil),
 		mockNetLink.EXPECT().LinkSetUp(mockENILink).Return(nil),
+		mockENILink.EXPECT().Attrs().Return(&netlink.LinkAttrs{Index: eniLinkIndex}),
 		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
 			assert.Equal(t, route.Gw.String(), eniIPV4Gateway)
 		}).Return(nil),
@@ -1147,7 +1167,8 @@ func TestSetupNamespaceClosureRun(t *testing.T) {
 			assert.Equal(t, route.LinkIndex, eniLinkIndex)
 		}).Return(nil),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, 0)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress,
+		[]string{eniIPV4CIDRBlock, eniIPV6CIDRBlock}, []string{eniIPV4Gateway, eniIPV6Gateway}, false, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)
@@ -1228,6 +1249,7 @@ func TestSetupNamespaceClosureRunWithMTU(t *testing.T) {
 		mockNetLink.EXPECT().AddrAdd(mockENILink, ipv6Address).Return(nil),
 		mockNetLink.EXPECT().LinkSetUp(mockENILink).Return(nil),
 		mockNetLink.EXPECT().LinkSetMTU(mockENILink, 9001).Return(nil),
+		mockENILink.EXPECT().Attrs().Return(&netlink.LinkAttrs{Index: eniLinkIndex}),
 		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
 			assert.Equal(t, route.Gw.String(), eniIPV4Gateway)
 		}).Return(nil),
@@ -1237,7 +1259,8 @@ func TestSetupNamespaceClosureRunWithMTU(t *testing.T) {
 			assert.Equal(t, route.LinkIndex, eniLinkIndex)
 		}).Return(nil),
 	)
-	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress, eniIPV4CIDRBlock, eniIPV6CIDRBlock, eniIPV4Gateway, eniIPV6Gateway, false, 9001)
+	closure, err := newSetupNamespaceClosureContext(mockNetLink, "eth0", deviceName, eniMACAddress,
+		[]string{eniIPV4CIDRBlock, eniIPV6CIDRBlock}, []string{eniIPV4Gateway, eniIPV6Gateway}, false, 9001)
 	assert.NoError(t, err)
 	assert.NotNil(t, closure)
 	err = closure.run(mockNetNS)

--- a/plugins/eni/engine/mocks/engine_mocks.go
+++ b/plugins/eni/engine/mocks/engine_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -169,17 +169,17 @@ func (mr *MockEngineMockRecorder) GetMACAddressOfENI(arg0, arg1 interface{}) *go
 }
 
 // SetupContainerNamespace mocks base method
-func (m *MockEngine) SetupContainerNamespace(arg0 *skel.CmdArgs, arg1, arg2, arg3, arg4, arg5, arg6 string, arg7, arg8 bool, arg9 int) error {
+func (m *MockEngine) SetupContainerNamespace(arg0 *skel.CmdArgs, arg1, arg2 string, arg3, arg4 []string, arg5, arg6 bool, arg7 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetupContainerNamespace", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+	ret := m.ctrl.Call(m, "SetupContainerNamespace", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetupContainerNamespace indicates an expected call of SetupContainerNamespace
-func (mr *MockEngineMockRecorder) SetupContainerNamespace(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 interface{}) *gomock.Call {
+func (mr *MockEngineMockRecorder) SetupContainerNamespace(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupContainerNamespace", reflect.TypeOf((*MockEngine)(nil).SetupContainerNamespace), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupContainerNamespace", reflect.TypeOf((*MockEngine)(nil).SetupContainerNamespace), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // TeardownContainerNamespace mocks base method

--- a/plugins/eni/types/types_test.go
+++ b/plugins/eni/types/types_test.go
@@ -23,39 +23,25 @@ import (
 )
 
 var (
-	validConfigNoIPV6                 = `{"eni":"eni1", "ipv4-address":"10.11.12.13", "mac":"01:23:45:67:89:ab"}`
-	configNoENIID                     = `{"ipv4-address":"10.11.12.13", "mac":"01:23:45:67:89:ab"}`
-	configNoIPV4Address               = `{"eni":"eni1", "mac":"01:23:45:67:89:ab"}`
-	configNoMAC                       = `{"eni":"eni1", "ipv4-address":"10.11.12.13"}`
-	configInvalidIPV4AddressMalformed = `{"eni":"eni1", "ipv4-address":"1", "mac":"01:23:45:67:89:ab"}`
-	configInvalidIPV4AddressIPV6      = `{"eni":"eni1", "ipv4-address":"2001:db8::68", "mac":"01:23:45:67:89:ab"}`
-	configMalformedMAC                = `{"eni":"eni1", "ipv4-address":"10.11.12.13", "mac":"01:23:45:67:89"}`
-	validConfigWithIPV6               = `{
-	"eni":"eni1",
-	"ipv4-address":"10.11.12.13",
-	"mac":"01:23:45:67:89:ab",
-	"ipv6-address":"2001:db8::68"
-}`
+	// Invalid configs.
+	configNoENIID                     = `{"ip-addresses":["10.11.12.13/16"], "mac":"01:23:45:67:89:ab"}`
+	configNoIPAddresses               = `{"eni":"eni1", "mac":"01:23:45:67:89:ab"}`
+	configNoMAC                       = `{"eni":"eni1", "ip-addresses":["10.11.12.13/16"]}`
+	configInvalidIPv4AddressMalformed = `{"eni":"eni1", "ip-addresses":["1"], "mac":"01:23:45:67:89:ab"}`
+	configInvalidIPv6AddressMalformed = `{"eni":"eni1", "ip-addresses":["2001:::68/64"], "mac":"01:23:45:67:89:ab"}`
+	configInvalidMultiAddrsMalformed  = `{"eni":"eni1", "ip-addresses":["10.11.12.13","2001:::68/64"], "mac":"01:23:45:67:89:ab"}`
+	configMalformedMAC                = `{"eni":"eni1", "ip-addresses":["10.11.12.13/16"], "mac":"01:23:45:67:89"}`
+
+	// Valid configs.
+	validConfigWithIPv4      = `{"eni":"eni1", "ip-addresses":["10.11.12.13/16"], "mac":"01:23:45:67:89:ab"}`
+	validConfigWithIPv6      = `{"eni":"eni1",	"ip-addresses":["2001:db8::68/64"], "mac":"01:23:45:67:89:ab"}`
 	validConfigWithAllFields = `{
 	"eni":"eni1",
-	"ipv4-address":"10.11.12.13",
+	"ip-addresses":["10.11.12.13/16","2001:db8::68/64"],
 	"mac":"01:23:45:67:89:ab",
-	"ipv6-address":"2001:db8::68",
 	"block-instance-metadata":true,
-	"subnetgateway-ipv4-address":"10.11.0.1/24",
+	"gateway-ip-addresses":["10.11.0.1", "fe80:1234::abcd:ef01"],
 	"stay-down":true
-}`
-	configInvalidIPV6AddressMalformed = `{
-	"eni":"eni1",
-	"ipv4-address":"10.11.12.13",
-	"mac":"01:23:45:67:89:ab",
-	"ipv6-address":"2001:::68"
-}`
-	configInvalidIPV6AddressIPV4 = `{
-	"eni":"eni1",
-	"ipv4-address":"10.11.12.13",
-	"mac":"01:23:45:67:89:ab",
-	"ipv6-address":"10.11.12.13"
 }`
 )
 
@@ -64,8 +50,8 @@ func TestNewConfWithValidConfig(t *testing.T) {
 		input string
 		name  string
 	}{
-		{validConfigNoIPV6, "no ipv6"},
-		{validConfigWithIPV6, "with ipv6"},
+		{validConfigWithIPv4, "with ipv4"},
+		{validConfigWithIPv6, "with ipv6"},
 		{validConfigWithAllFields, "all fields"},
 	}
 	for _, tc := range testCases {
@@ -86,13 +72,12 @@ func TestNewConfWithInvalidConfig(t *testing.T) {
 	}{
 		{`{"foo":"eni1"}`, "invalid keys"},
 		{configNoENIID, "no eni id"},
-		{configNoIPV4Address, "no ipv4 addr"},
+		{configNoIPAddresses, "no ip addr"},
 		{configNoMAC, "no mac"},
-		{configInvalidIPV4AddressMalformed, "malformed ipv4 addr"},
-		{configInvalidIPV4AddressIPV6, "invalid ipv4 address"},
+		{configInvalidIPv4AddressMalformed, "malformed ipv4 addr"},
+		{configInvalidIPv6AddressMalformed, "malformed ipv6 address"},
+		{configInvalidMultiAddrsMalformed, "multiple IP addresses some invalid"},
 		{configMalformedMAC, "malformed mac"},
-		{configInvalidIPV6AddressMalformed, "malformed ipv5 address"},
-		{configInvalidIPV6AddressIPV4, "valid ipv4 malformed ipv6"},
 		{"", "empty config"},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR updates ecs-eni plugin to support assigning multiple IP addresses and gateways per container network interface. The addresses and gateways can be any combination of IPv4 and IPv6 addresses.

### Implementation details
<!-- How are the changes implemented? -->
Design and implementation details are as discussed in the design meeting.

### Testing
<!-- How was this tested? -->
All unit, integration and e2e tests are updated and pass.

New tests cover the changes: <!-- yes|no -->
Yes. Unit tests are updated to cover the new functionality. I wanted to add IPv6 addresses to the end-to-end test, however that requires updating the vendored AWS SDK as the current version does not support IPv6.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
Feature - Support multiple IP (v4 and v6) addresses per interface

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
