### PR TITLE
Set static MAC address when creating ecs-bridge bridge

### DIFF
--- a/pkg/netlinkwrapper/netlink.go
+++ b/pkg/netlinkwrapper/netlink.go
@@ -13,7 +13,11 @@
 
 package netlinkwrapper
 
-import "github.com/vishvananda/netlink"
+import (
+	"net"
+
+	"github.com/vishvananda/netlink"
+)
 
 // NetLink wraps methods used from the vishvananda/netlink package
 type NetLink interface {
@@ -35,6 +39,8 @@ type NetLink interface {
 	LinkSetName(link netlink.Link, name string) error
 	// LinkSetUp is equivalent to `ip link set $link up`
 	LinkSetUp(link netlink.Link) error
+	// LinkSetHardwareAddr sets the hardware address of the link device. Equivalent to: `ip link set $link address $hwaddr`
+	LinkSetHardwareAddr(link netlink.Link, hwaddr net.HardwareAddr) error
 	// LinkSetMTU is equivalent to `ip link set $link mtu $mtu`
 	LinkSetMTU(link netlink.Link, mtu int) error
 	// LinkList is equivalent to: `ip link show`
@@ -85,6 +91,10 @@ func (*netLink) LinkSetUp(link netlink.Link) error {
 
 func (*netLink) LinkSetName(link netlink.Link, name string) error {
 	return netlink.LinkSetName(link, name)
+}
+
+func (*netLink) LinkSetHardwareAddr(link netlink.Link, hwaddr net.HardwareAddr) error {
+	return netlink.LinkSetHardwareAddr(link, hwaddr)
 }
 
 func (*netLink) LinkSetMTU(link netlink.Link, mtu int) error {


### PR DESCRIPTION
The ecs-bridge bridge currently is created without setting a static MAC address. This means that the bridge MAC address inherits the 'lowest' MAC address of all of it's connected veth interfaces.

What this means for ECS tasks using awsvpc networking mode is that the MAC address of ecs-bridge can be changing as tasks are killed an added to an instance (on the ec2 launch type).

This presents a race condition where some tasks might have an arpcache entry pointing to the old MAC address when a task is killed and the ecs-bridge MAC changes. In rare cases this can lead to brief periods of lost network connectivity within the local network on the host (such as requests to the ECS Task Metadata Endpoint or the ECS credentials endpoint).

By setting a static MAC address at creation we disable this behavior of inheriting the 'lowest' MAC address. This means that the ecs-bridge MAC stays constant through the entire lifetime of the ECS container instance.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Testing
<!-- How was this tested? -->

Tested on a container instance using awsvpc network mode. Verified that MAC address is set and stays constant through many task starts/stops.

Ran ECS agent functional testing suite.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->

bugfix: Set static MAC address when creating ecs-bridge bridge

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
