### PR TITLE
Bridge plugin updates to define a route from replica task to daemon t…

### DIFF
--- a/plugins/ecs-bridge/commands/commands.go
+++ b/plugins/ecs-bridge/commands/commands.go
@@ -133,17 +133,19 @@ func add(args *skel.CmdArgs, engine engine.Engine) error {
 		result.IPs[i].Interface = 2
 	}
 
+	// Configure bridge first so gateway IP exists before adding container routes
+	detailLogInfo("Configuring bridge", args, conf, hostVethName)
+	err = engine.ConfigureBridge(result, bridge)
+	if err != nil {
+		return err
+	}
+
 	detailLogInfo("Configuring container's interface", args, conf, hostVethName)
 	err = engine.ConfigureContainerVethInterface(args.Netns, result, args.IfName)
 	if err != nil {
 		return err
 	}
 
-	detailLogInfo("Configuring bridge", args, conf, hostVethName)
-	err = engine.ConfigureBridge(result, bridge)
-	if err != nil {
-		return err
-	}
 	return result.Print()
 }
 

--- a/plugins/ecs-bridge/engine/bridge_static_ip_test.go
+++ b/plugins/ecs-bridge/engine/bridge_static_ip_test.go
@@ -1,0 +1,467 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+)
+
+// TestConfigureBridge_LinkLocalIPv4_UsesCIDR22 tests that bridge gets /22 mask for link-local IPv4
+func TestConfigureBridge_LinkLocalIPv4_UsesCIDR22(t *testing.T) {
+	ctrl, _, mockNetLink, _, _, _ := setup(t)
+	defer ctrl.Finish()
+
+	bridgeLink := &netlink.Bridge{
+		LinkAttrs: netlink.LinkAttrs{Name: "fargate-bridge"},
+	}
+
+	// Link-local gateway IP (169.254.x.x)
+	gatewayIP := net.ParseIP("169.254.172.1")
+	containerIP := net.ParseIP("169.254.172.2")
+
+	ipConfig := &current.IPConfig{
+		Address: net.IPNet{
+			IP:   containerIP,
+			Mask: net.CIDRMask(32, 32), // Container has /32
+		},
+		Gateway: gatewayIP,
+	}
+
+	result := &current.Result{
+		IPs: []*current.IPConfig{ipConfig},
+	}
+
+	// Expected bridge address should have /22 mask, not /32
+	expectedBridgeAddr := &netlink.Addr{
+		IPNet: &net.IPNet{
+			IP:   gatewayIP,
+			Mask: net.CIDRMask(22, 32), // Bridge gets /22
+		},
+	}
+
+	gomock.InOrder(
+		mockNetLink.EXPECT().AddrList(bridgeLink, syscall.AF_INET).Return(nil, nil),
+		mockNetLink.EXPECT().AddrAdd(bridgeLink, expectedBridgeAddr).Return(nil),
+	)
+
+	engine := &engine{netLink: mockNetLink}
+	err := engine.ConfigureBridge(result, bridgeLink)
+	assert.NoError(t, err)
+}
+
+// TestConfigureBridge_LinkLocalIPv6_UsesCIDR64 tests that bridge gets /64 mask for link-local IPv6
+func TestConfigureBridge_LinkLocalIPv6_UsesCIDR64(t *testing.T) {
+	ctrl, _, mockNetLink, _, _, _ := setup(t)
+	defer ctrl.Finish()
+
+	bridgeLink := &netlink.Bridge{
+		LinkAttrs: netlink.LinkAttrs{Name: "fargate-bridge"},
+	}
+
+	// Link-local IPv6 gateway
+	gatewayIP := net.ParseIP("fe80::1")
+	containerIP := net.ParseIP("fe80::2")
+
+	ipConfig := &current.IPConfig{
+		Address: net.IPNet{
+			IP:   containerIP,
+			Mask: net.CIDRMask(128, 128), // Container has /128
+		},
+		Gateway: gatewayIP,
+	}
+
+	result := &current.Result{
+		IPs: []*current.IPConfig{ipConfig},
+	}
+
+	// Expected bridge address should have /64 mask
+	expectedBridgeAddr := &netlink.Addr{
+		IPNet: &net.IPNet{
+			IP:   gatewayIP,
+			Mask: net.CIDRMask(64, 128), // Bridge gets /64
+		},
+	}
+
+	gomock.InOrder(
+		mockNetLink.EXPECT().AddrList(bridgeLink, syscall.AF_INET6).Return(nil, nil),
+		mockNetLink.EXPECT().AddrAdd(bridgeLink, expectedBridgeAddr).Return(nil),
+	)
+
+	engine := &engine{netLink: mockNetLink}
+	err := engine.ConfigureBridge(result, bridgeLink)
+	assert.NoError(t, err)
+}
+
+// TestConfigureBridge_NonLinkLocalIP_UsesContainerMask tests that non-link-local IPs use container mask
+func TestConfigureBridge_NonLinkLocalIP_UsesContainerMask(t *testing.T) {
+	ctrl, _, mockNetLink, _, _, _ := setup(t)
+	defer ctrl.Finish()
+
+	bridgeLink := &netlink.Bridge{
+		LinkAttrs: netlink.LinkAttrs{Name: "fargate-bridge"},
+	}
+
+	// Regular private IP (not link-local)
+	gatewayIP := net.ParseIP("10.0.0.1")
+	containerIP := net.ParseIP("10.0.0.2")
+
+	ipConfig := &current.IPConfig{
+		Address: net.IPNet{
+			IP:   containerIP,
+			Mask: net.CIDRMask(24, 32), // Container has /24
+		},
+		Gateway: gatewayIP,
+	}
+
+	result := &current.Result{
+		IPs: []*current.IPConfig{ipConfig},
+	}
+
+	// Expected bridge address should use container's /24 mask
+	expectedBridgeAddr := &netlink.Addr{
+		IPNet: &net.IPNet{
+			IP:   gatewayIP,
+			Mask: net.CIDRMask(24, 32), // Bridge uses container mask
+		},
+	}
+
+	gomock.InOrder(
+		mockNetLink.EXPECT().AddrList(bridgeLink, syscall.AF_INET).Return(nil, nil),
+		mockNetLink.EXPECT().AddrAdd(bridgeLink, expectedBridgeAddr).Return(nil),
+	)
+
+	engine := &engine{netLink: mockNetLink}
+	err := engine.ConfigureBridge(result, bridgeLink)
+	assert.NoError(t, err)
+}
+
+// TestConfigureBridge_BeforeContainer tests that bridge is configured before container
+// This is important because container configuration adds routes to the gateway,
+// which must already exist on the bridge
+func TestConfigureBridge_BeforeContainer(t *testing.T) {
+	// This test verifies the order of operations in commands.go
+	// The actual test is in commands_test.go, but we document the requirement here
+	// 
+	// Required order:
+	// 1. ConfigureBridge() - Gateway IP must exist first
+	// 2. ConfigureContainerVethInterface() - Container adds routes to gateway
+	//
+	// If reversed, container route addition may fail or behave unpredictably
+}
+
+// TestConfigureVeth_AddsOnLinkGatewayRoute tests that on-link gateway route is added
+func TestConfigureVeth_AddsOnLinkGatewayRoute(t *testing.T) {
+	ctrl, _, mockNetLink, mockIP, mockIPAM, _ := setup(t)
+	defer ctrl.Finish()
+
+	gatewayIP := net.ParseIP("169.254.172.1")
+	containerIP := net.ParseIP("169.254.172.2")
+
+	ipConfig := &current.IPConfig{
+		Address: net.IPNet{
+			IP:   containerIP,
+			Mask: net.CIDRMask(32, 32),
+		},
+		Gateway: gatewayIP,
+	}
+
+	result := &current.Result{
+		IPs: []*current.IPConfig{ipConfig},
+	}
+
+	link := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:  "eth0",
+			Index: 1,
+		},
+	}
+
+	var capturedGatewayRoute, capturedSubnetRoute *netlink.Route
+
+	gomock.InOrder(
+		// Get link for adding on-link routes
+		mockNetLink.EXPECT().LinkByName("eth0").Return(link, nil),
+		// Add on-link gateway route - capture it
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
+			capturedGatewayRoute = route
+		}).Return(nil),
+		// ConfigureIface
+		mockIPAM.EXPECT().ConfigureIface("eth0", result).Return(nil),
+		// SetHWAddrByIP
+		mockIP.EXPECT().SetHWAddrByIP("eth0", containerIP, nil).Return(nil),
+		// RouteList for cleanup
+		mockNetLink.EXPECT().RouteList(link, netlink.FAMILY_ALL).Return([]netlink.Route{}, nil),
+		// Add connected subnet route - capture it
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
+			capturedSubnetRoute = route
+		}).Return(nil),
+	)
+
+	configContext := newConfigureVethContext("eth0", result, mockIP, mockIPAM, mockNetLink)
+	err := configContext.run(nil)
+	assert.NoError(t, err)
+
+	// Verify gateway route
+	assert.NotNil(t, capturedGatewayRoute)
+	assert.Equal(t, gatewayIP.String(), capturedGatewayRoute.Dst.IP.String())
+	assert.Equal(t, net.CIDRMask(32, 32).String(), capturedGatewayRoute.Dst.Mask.String())
+	assert.Equal(t, netlink.SCOPE_LINK, capturedGatewayRoute.Scope)
+
+	// Verify subnet route
+	assert.NotNil(t, capturedSubnetRoute)
+	assert.Equal(t, containerIP.String(), capturedSubnetRoute.Dst.IP.String())
+	assert.Equal(t, net.CIDRMask(32, 32).String(), capturedSubnetRoute.Dst.Mask.String())
+	assert.Equal(t, netlink.SCOPE_LINK, capturedSubnetRoute.Scope)
+}
+
+// TestConfigureVeth_DeletesOnlyDefaultRoutes tests that only default routes are deleted
+func TestConfigureVeth_DeletesOnlyDefaultRoutes(t *testing.T) {
+	ctrl, _, mockNetLink, mockIP, mockIPAM, _ := setup(t)
+	defer ctrl.Finish()
+
+	gatewayIP := net.ParseIP("169.254.172.1")
+	containerIP := net.ParseIP("169.254.172.2")
+
+	ipConfig := &current.IPConfig{
+		Address: net.IPNet{
+			IP:   containerIP,
+			Mask: net.CIDRMask(32, 32),
+		},
+		Gateway: gatewayIP,
+	}
+
+	result := &current.Result{
+		IPs: []*current.IPConfig{ipConfig},
+	}
+
+	link := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:  "eth0",
+			Index: 1,
+		},
+	}
+
+	// Existing routes in container
+	existingRoutes := []netlink.Route{
+		// Default route - should be deleted
+		{
+			Dst: nil, // nil means default route
+			Gw:  nil,
+		},
+		// On-link gateway route - should NOT be deleted
+		{
+			Dst: &net.IPNet{
+				IP:   gatewayIP,
+				Mask: net.CIDRMask(32, 32),
+			},
+			Gw:    nil,
+			Scope: netlink.SCOPE_LINK,
+		},
+		// Route with gateway - should NOT be deleted
+		{
+			Dst: &net.IPNet{
+				IP:   net.ParseIP("10.0.0.0"),
+				Mask: net.CIDRMask(8, 32),
+			},
+			Gw: gatewayIP,
+		},
+	}
+
+	// Only the default route should be deleted
+	expectedDeleteRoute := &netlink.Route{
+		Dst: nil,
+		Gw:  nil,
+	}
+
+	gomock.InOrder(
+		mockNetLink.EXPECT().LinkByName("eth0").Return(link, nil),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil), // Gateway route
+		mockIPAM.EXPECT().ConfigureIface("eth0", result).Return(nil),
+		mockIP.EXPECT().SetHWAddrByIP("eth0", containerIP, nil).Return(nil),
+		mockNetLink.EXPECT().RouteList(link, netlink.FAMILY_ALL).Return(existingRoutes, nil),
+		// Only default route should be deleted
+		mockNetLink.EXPECT().RouteDel(expectedDeleteRoute).Return(nil),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil), // Subnet route
+	)
+
+	configContext := newConfigureVethContext("eth0", result, mockIP, mockIPAM, mockNetLink)
+	err := configContext.run(nil)
+	assert.NoError(t, err)
+}
+
+// TestConfigureVeth_AddsConnectedSubnetRoute tests that connected subnet route is added
+func TestConfigureVeth_AddsConnectedSubnetRoute(t *testing.T) {
+	ctrl, _, mockNetLink, mockIP, mockIPAM, _ := setup(t)
+	defer ctrl.Finish()
+
+	gatewayIP := net.ParseIP("169.254.172.1")
+	containerIP := net.ParseIP("169.254.172.2")
+
+	ipConfig := &current.IPConfig{
+		Address: net.IPNet{
+			IP:   containerIP,
+			Mask: net.CIDRMask(32, 32),
+		},
+		Gateway: gatewayIP,
+	}
+
+	result := &current.Result{
+		IPs: []*current.IPConfig{ipConfig},
+	}
+
+	link := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:  "eth0",
+			Index: 1,
+		},
+	}
+
+	var capturedSubnetRoute *netlink.Route
+
+	gomock.InOrder(
+		mockNetLink.EXPECT().LinkByName("eth0").Return(link, nil),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil), // Gateway route
+		mockIPAM.EXPECT().ConfigureIface("eth0", result).Return(nil),
+		mockIP.EXPECT().SetHWAddrByIP("eth0", containerIP, nil).Return(nil),
+		mockNetLink.EXPECT().RouteList(link, netlink.FAMILY_ALL).Return([]netlink.Route{}, nil),
+		// Connected subnet route should be added - capture it
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
+			capturedSubnetRoute = route
+		}).Return(nil),
+	)
+
+	configContext := newConfigureVethContext("eth0", result, mockIP, mockIPAM, mockNetLink)
+	err := configContext.run(nil)
+	assert.NoError(t, err)
+
+	// Verify subnet route
+	assert.NotNil(t, capturedSubnetRoute)
+	assert.Equal(t, containerIP.String(), capturedSubnetRoute.Dst.IP.String())
+	assert.Equal(t, net.CIDRMask(32, 32).String(), capturedSubnetRoute.Dst.Mask.String())
+	assert.Equal(t, netlink.SCOPE_LINK, capturedSubnetRoute.Scope)
+}
+
+// TestConfigureVeth_HandlesExistingRoutes tests that existing routes don't cause errors
+func TestConfigureVeth_HandlesExistingRoutes(t *testing.T) {
+	ctrl, _, mockNetLink, mockIP, mockIPAM, _ := setup(t)
+	defer ctrl.Finish()
+
+	gatewayIP := net.ParseIP("169.254.172.1")
+	containerIP := net.ParseIP("169.254.172.2")
+
+	ipConfig := &current.IPConfig{
+		Address: net.IPNet{
+			IP:   containerIP,
+			Mask: net.CIDRMask(32, 32),
+		},
+		Gateway: gatewayIP,
+	}
+
+	result := &current.Result{
+		IPs: []*current.IPConfig{ipConfig},
+	}
+
+	link := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:  "eth0",
+			Index: 1,
+		},
+	}
+
+	// Simulate "file exists" error for routes that already exist
+	fileExistsErr := &os.PathError{Op: "add", Path: "route", Err: syscall.EEXIST}
+
+	gomock.InOrder(
+		mockNetLink.EXPECT().LinkByName("eth0").Return(link, nil),
+		// Gateway route already exists
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(fileExistsErr),
+		mockIPAM.EXPECT().ConfigureIface("eth0", result).Return(nil),
+		mockIP.EXPECT().SetHWAddrByIP("eth0", containerIP, nil).Return(nil),
+		mockNetLink.EXPECT().RouteList(link, netlink.FAMILY_ALL).Return([]netlink.Route{}, nil),
+		// Subnet route already exists
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(fileExistsErr),
+	)
+
+	configContext := newConfigureVethContext("eth0", result, mockIP, mockIPAM, mockNetLink)
+	err := configContext.run(nil)
+	// Should not error on "file exists"
+	assert.NoError(t, err)
+}
+
+// TestConfigureVeth_DualStack tests on-link routes for both IPv4 and IPv6
+func TestConfigureVeth_DualStack(t *testing.T) {
+	ctrl, _, mockNetLink, mockIP, mockIPAM, _ := setup(t)
+	defer ctrl.Finish()
+
+	gatewayIPv4 := net.ParseIP("169.254.172.1")
+	containerIPv4 := net.ParseIP("169.254.172.2")
+	gatewayIPv6 := net.ParseIP("fd00:ec2::172:1")
+	containerIPv6 := net.ParseIP("fd00:ec2::172:2")
+
+	ipConfigV4 := &current.IPConfig{
+		Address: net.IPNet{
+			IP:   containerIPv4,
+			Mask: net.CIDRMask(32, 32),
+		},
+		Gateway: gatewayIPv4,
+	}
+
+	ipConfigV6 := &current.IPConfig{
+		Address: net.IPNet{
+			IP:   containerIPv6,
+			Mask: net.CIDRMask(128, 128),
+		},
+		Gateway: gatewayIPv6,
+	}
+
+	result := &current.Result{
+		IPs: []*current.IPConfig{ipConfigV4, ipConfigV6},
+	}
+
+	link := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:  "eth0",
+			Index: 1,
+		},
+	}
+
+	gomock.InOrder(
+		mockNetLink.EXPECT().LinkByName("eth0").Return(link, nil),
+		// IPv4 gateway route
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		// IPv6 gateway route
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		mockIPAM.EXPECT().ConfigureIface("eth0", result).Return(nil),
+		// SetHWAddrByIP is called with both IPv4 and IPv6
+		mockIP.EXPECT().SetHWAddrByIP("eth0", containerIPv4, containerIPv6).Return(nil),
+		mockNetLink.EXPECT().RouteList(link, netlink.FAMILY_ALL).Return([]netlink.Route{}, nil),
+		// IPv4 subnet route
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		// IPv6 subnet route
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+	)
+
+	configContext := newConfigureVethContext("eth0", result, mockIP, mockIPAM, mockNetLink)
+	err := configContext.run(nil)
+	require.NoError(t, err)
+}

--- a/plugins/ecs-bridge/engine/configureveth.go
+++ b/plugins/ecs-bridge/engine/configureveth.go
@@ -15,12 +15,12 @@ package engine
 
 import (
 	"net"
+	"os"
 
 	"github.com/aws/amazon-ecs-cni-plugins/pkg/cniipamwrapper"
 	"github.com/aws/amazon-ecs-cni-plugins/pkg/cniipwrapper"
 	"github.com/aws/amazon-ecs-cni-plugins/pkg/netlinkwrapper"
 	"github.com/containernetworking/cni/pkg/ns"
-	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
@@ -54,32 +54,42 @@ func newConfigureVethContext(interfaceName string,
 // run defines the closure to execute within the container's namespace to
 // configure the veth interface
 func (configContext *configureVethContext) run(hostNS ns.NetNS) error {
-	// Add gateway routes for each IP configuration BEFORE ConfigureIface
-	// For IPv4: /32 route for ARP query request from host
-	// For IPv6: /128 route for neighbor discovery
-	// These routes have an explicit gateway set to the gateway IP itself,
-	// which ConfigureIface will use when adding the route.
+	// Get the link first so we can add on-link routes before ConfigureIface
+	link, err := configContext.netLink.LinkByName(configContext.interfaceName)
+	if err != nil {
+		return errors.Wrapf(err,
+			"bridge configure veth: unable to get link for interface: %s",
+			configContext.interfaceName)
+	}
+
+	// Add on-link routes to the gateway BEFORE ConfigureIface
+	// This makes the gateway directly reachable for containers with /32 or /128 addresses
 	for _, ipConfig := range configContext.result.IPs {
 		var maskBits int
 		if ipConfig.Address.IP.To4() != nil {
-			maskBits = 32 // IPv4: /32 for gateway route
+			maskBits = 32
 		} else {
-			maskBits = 128 // IPv6: /128 for gateway route
+			maskBits = 128
 		}
 
-		route := &types.Route{
-			Dst: net.IPNet{
+		gatewayRoute := &netlink.Route{
+			LinkIndex: link.Attrs().Index,
+			Dst: &net.IPNet{
 				IP:   ipConfig.Gateway,
 				Mask: net.CIDRMask(maskBits, maskBits),
 			},
-			// Set explicit gateway so ConfigureIface uses it
-			GW: ipConfig.Gateway,
+			Scope: netlink.SCOPE_LINK,
 		}
-		configContext.result.Routes = append(configContext.result.Routes, route)
+
+		err = configContext.netLink.RouteAdd(gatewayRoute)
+		if err != nil && !os.IsExist(err) {
+			return errors.Wrapf(err,
+				"bridge configure veth: unable to add gateway route: %v", gatewayRoute)
+		}
 	}
 
 	// Configure routes in the container (handles both IPv4 and IPv6)
-	err := configContext.ipam.ConfigureIface(
+	err = configContext.ipam.ConfigureIface(
 		configContext.interfaceName, configContext.result)
 	if err != nil {
 		return errors.Wrapf(err,
@@ -113,13 +123,7 @@ func (configContext *configureVethContext) run(hostNS ns.NetNS) error {
 		}
 	}
 
-	link, err := configContext.netLink.LinkByName(configContext.interfaceName)
-	if err != nil {
-		return errors.Wrapf(err,
-			"bridge configure veth: unable to get link for interface: %s",
-			configContext.interfaceName)
-	}
-
+	// link was already retrieved at the beginning of run()
 	// Delete default routes for ALL address families (both IPv4 and IPv6)
 	routes, err := configContext.netLink.RouteList(link, netlink.FAMILY_ALL)
 	if err != nil {
@@ -128,15 +132,49 @@ func (configContext *configureVethContext) run(hostNS ns.NetNS) error {
 			configContext.interfaceName)
 	}
 
-	// Delete all default routes within the container (routes without a gateway)
-	// Routes with a gateway (including our gateway routes) will be preserved
+	// Delete only default routes (0.0.0.0/0 or ::/0) within the container
+	// Preserve routes with gateways and connected subnet routes
 	for _, route := range routes {
-		if route.Gw == nil {
+		// Skip routes with a gateway
+		if route.Gw != nil {
+			continue
+		}
+		
+		// Check if this is a default route
+		isDefaultRoute := route.Dst == nil || 
+			route.Dst.String() == "0.0.0.0/0" || 
+			route.Dst.String() == "::/0"
+		
+		if isDefaultRoute {
 			err = configContext.netLink.RouteDel(&route)
 			if err != nil {
 				return errors.Wrapf(err,
 					"bridge configure veth: unable to delete route: %v", route)
 			}
+		}
+	}
+
+	// Explicitly add connected subnet route after cleanup
+	// This route allows the container to reach other IPs in the same bridge subnet
+	for _, ipConfig := range configContext.result.IPs {
+		// Calculate the subnet network address
+		subnetIP := ipConfig.Address.IP.Mask(ipConfig.Address.Mask)
+		
+		// Add the connected subnet route
+		subnetRoute := &netlink.Route{
+			LinkIndex: link.Attrs().Index,
+			Dst: &net.IPNet{
+				IP:   subnetIP,
+				Mask: ipConfig.Address.Mask,
+			},
+			Scope: netlink.SCOPE_LINK,
+		}
+		
+		// Add the route, ignoring if it already exists
+		err = configContext.netLink.RouteAdd(subnetRoute)
+		if err != nil && !os.IsExist(err) {
+			return errors.Wrapf(err,
+				"bridge configure veth: unable to add connected subnet route: %v", subnetRoute)
 		}
 	}
 

--- a/plugins/ecs-bridge/engine/engine.go
+++ b/plugins/ecs-bridge/engine/engine.go
@@ -267,7 +267,9 @@ func (engine *engine) ConfigureContainerVethInterface(netnsName string, result *
 
 // ConfigureBridge configures the IP addresses of the bridge for all address families
 func (engine *engine) ConfigureBridge(result *current.Result, bridge *netlink.Bridge) error {
+	log.Infof("ConfigureBridge called with %d IP configs", len(result.IPs))
 	for _, ipConfig := range result.IPs {
+		log.Infof("Processing IP config - Address=%s, Gateway=%s", ipConfig.Address.String(), ipConfig.Gateway)
 		// Determine address family based on IP version
 		family := syscall.AF_INET
 		if ipConfig.Address.IP.To4() == nil {
@@ -280,11 +282,28 @@ func (engine *engine) ConfigureBridge(result *current.Result, bridge *netlink.Br
 				"bridge configure: unable to list addresses for bridge %s",
 				bridge.Attrs().Name)
 		}
+		log.Infof("Bridge has %d existing addresses for family %d", len(addrs), family)
+
+		// For daemon bridge (169.254.172.x), use /22 subnet mask for gateway
+		// Container gets /32, but bridge needs /22 to route the entire subnet
+		bridgeMask := ipConfig.Address.Mask
+		log.Infof("Gateway IP=%s, IsLinkLocal=%v, To4=%v, ContainerMask=%s",
+			ipConfig.Gateway, ipConfig.Gateway.IsLinkLocalUnicast(), ipConfig.Gateway.To4(), ipConfig.Address.Mask)
+		if ipConfig.Gateway.IsLinkLocalUnicast() && ipConfig.Gateway.To4() != nil {
+			// IPv4 link-local (169.254.x.x) - use /22
+			bridgeMask = net.CIDRMask(22, 32)
+			log.Infof("Applying /22 mask to link-local gateway")
+		} else if ipConfig.Gateway.IsLinkLocalUnicast() && ipConfig.Gateway.To4() == nil {
+			// IPv6 link-local - use /64
+			bridgeMask = net.CIDRMask(64, 128)
+			log.Infof("Applying /64 mask to IPv6 link-local gateway")
+		}
 
 		resultBridgeNetwork := &net.IPNet{
 			IP:   ipConfig.Gateway,
-			Mask: ipConfig.Address.Mask,
+			Mask: bridgeMask,
 		}
+		log.Infof("Bridge will get IP=%s", resultBridgeNetwork.String())
 		resultBridgeCIDR := resultBridgeNetwork.String()
 
 		addressExists := false
@@ -303,6 +322,7 @@ func (engine *engine) ConfigureBridge(result *current.Result, bridge *netlink.Br
 		}
 
 		if addressExists {
+			log.Infof("Address %s already exists on bridge, skipping", resultBridgeCIDR)
 			continue
 		}
 

--- a/plugins/ecs-bridge/engine/engine_test.go
+++ b/plugins/ecs-bridge/engine/engine_test.go
@@ -638,7 +638,15 @@ func TestConfigureContainerVethInterfaceConfigureIfaceError(t *testing.T) {
 			},
 		},
 	}
-	mockIPAM.EXPECT().ConfigureIface(interfaceName, result).Return(errors.New("error"))
+	
+	link := &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: interfaceName, Index: 1}}
+	
+	gomock.InOrder(
+		mockNetLink.EXPECT().LinkByName(interfaceName).Return(link, nil),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		mockIPAM.EXPECT().ConfigureIface(interfaceName, result).Return(errors.New("error")),
+	)
+	
 	configContext := newConfigureVethContext(
 		interfaceName, result, mockIP, mockIPAM, mockNetLink)
 	err = configContext.run(nil)
@@ -663,7 +671,11 @@ func TestConfigureContainerVethInterfaceSetHWAddrByIPError(t *testing.T) {
 		IPs: []*current.IPConfig{ipConfig},
 	}
 
+	link := &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: interfaceName, Index: 1}}
+
 	gomock.InOrder(
+		mockNetLink.EXPECT().LinkByName(interfaceName).Return(link, nil),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 		mockIP.EXPECT().SetHWAddrByIP(interfaceName, containerIPAddr, nil).Return(errors.New("error")),
 	)
@@ -692,8 +704,6 @@ func TestConfigureContainerVethInterfaceLinkByNameError(t *testing.T) {
 	}
 
 	gomock.InOrder(
-		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
-		mockIP.EXPECT().SetHWAddrByIP(interfaceName, containerIPAddr, nil).Return(nil),
 		mockNetLink.EXPECT().LinkByName(interfaceName).Return(nil, errors.New("error")),
 	)
 	configContext := newConfigureVethContext(
@@ -721,11 +731,14 @@ func TestConfigureContainerVethInterfaceRouteListError(t *testing.T) {
 	}
 
 	mockLink := mock_netlink.NewMockLink(ctrl)
+	mockAttrs := &netlink.LinkAttrs{Index: 1}
 
 	gomock.InOrder(
+		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 		mockIP.EXPECT().SetHWAddrByIP(interfaceName, containerIPAddr, nil).Return(nil),
-		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
 		mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(nil, errors.New("error")),
 	)
 	configContext := newConfigureVethContext(
@@ -753,13 +766,16 @@ func TestConfigureContainerVethInterfaceRouteDelError(t *testing.T) {
 	}
 
 	mockLink := mock_netlink.NewMockLink(ctrl)
+	mockAttrs := &netlink.LinkAttrs{Index: 1}
 	// Route without gateway (default route) should be deleted
 	route := netlink.Route{Gw: nil}
 	routes := []netlink.Route{route}
 	gomock.InOrder(
+		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 		mockIP.EXPECT().SetHWAddrByIP(interfaceName, containerIPAddr, nil).Return(nil),
-		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
 		mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
 		mockNetLink.EXPECT().RouteDel(&route).Return(errors.New("error")),
 	)
@@ -787,16 +803,21 @@ func TestConfigureContainerVethInterfaceContextSuccess(t *testing.T) {
 		IPs: []*current.IPConfig{ipConfig},
 	}
 
+	mockAttrs := &netlink.LinkAttrs{Index: 1}
 	mockLink := mock_netlink.NewMockLink(ctrl)
 	// Route without gateway (default route) should be deleted
 	route := netlink.Route{Gw: nil}
 	routes := []netlink.Route{route}
 	gomock.InOrder(
+		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 		mockIP.EXPECT().SetHWAddrByIP(interfaceName, containerIPAddr, nil).Return(nil),
-		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
 		mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
 		mockNetLink.EXPECT().RouteDel(&route).Return(nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 	)
 	configContext := newConfigureVethContext(
 		interfaceName, result, mockIP, mockIPAM, mockNetLink)
@@ -2220,20 +2241,18 @@ func TestConfigureContainerVethInterfaceIPv6OnlySuccess(t *testing.T) {
 	}
 
 	mockLink := mock_netlink.NewMockLink(ctrl)
+	mockAttrs := &netlink.LinkAttrs{Index: 1}
 	routes := []netlink.Route{}
 	gomock.InOrder(
-		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).DoAndReturn(
-			func(ifName string, res *current.Result) error {
-				// Verify gateway route for IPv6 was added
-				assert.Equal(t, 1, len(res.Routes), "should have 1 gateway route")
-				ones, _ := res.Routes[0].Dst.Mask.Size()
-				assert.Equal(t, 128, ones, "IPv6 gateway route should be /128")
-				return nil
-			}),
+		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 		// For IPv6-only, SetHWAddrByIP uses nil for IPv4 and the IPv6 address
 		mockIP.EXPECT().SetHWAddrByIP(interfaceName, nil, ipv6ContainerAddr).Return(nil),
-		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
 		mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 	)
 	configContext := newConfigureVethContext(
 		interfaceName, result, mockIP, mockIPAM, mockNetLink)
@@ -2273,24 +2292,22 @@ func TestConfigureContainerVethInterfaceDualStackSuccess(t *testing.T) {
 	}
 
 	mockLink := mock_netlink.NewMockLink(ctrl)
+	mockAttrs := &netlink.LinkAttrs{Index: 1}
 	routes := []netlink.Route{}
 	gomock.InOrder(
-		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).DoAndReturn(
-			func(ifName string, res *current.Result) error {
-				// Verify gateway routes for both IPv4 and IPv6 were added
-				assert.Equal(t, 2, len(res.Routes), "should have 2 gateway routes")
-				// First route should be IPv4 /32
-				ones, _ := res.Routes[0].Dst.Mask.Size()
-				assert.Equal(t, 32, ones, "IPv4 gateway route should be /32")
-				// Second route should be IPv6 /128
-				ones, _ = res.Routes[1].Dst.Mask.Size()
-				assert.Equal(t, 128, ones, "IPv6 gateway route should be /128")
-				return nil
-			}),
+		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 		// For dual-stack, SetHWAddrByIP uses both IPv4 and IPv6 addresses
 		mockIP.EXPECT().SetHWAddrByIP(interfaceName, ipv4ContainerAddr, ipv6ContainerAddr).Return(nil),
-		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
 		mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 	)
 	configContext := newConfigureVethContext(
 		interfaceName, result, mockIP, mockIPAM, mockNetLink)
@@ -2331,24 +2348,22 @@ func TestConfigureContainerVethInterfaceDualStackIPv6FirstSuccess(t *testing.T) 
 	}
 
 	mockLink := mock_netlink.NewMockLink(ctrl)
+	mockAttrs := &netlink.LinkAttrs{Index: 1}
 	routes := []netlink.Route{}
 	gomock.InOrder(
-		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).DoAndReturn(
-			func(ifName string, res *current.Result) error {
-				// Verify gateway routes for both IPv6 and IPv4
-				assert.Equal(t, 2, len(res.Routes), "should have 2 gateway routes")
-				// First route should be IPv6 /128
-				ones, _ := res.Routes[0].Dst.Mask.Size()
-				assert.Equal(t, 128, ones, "first gateway route should be /128 for IPv6")
-				// Second route should be IPv4 /32
-				ones, _ = res.Routes[1].Dst.Mask.Size()
-				assert.Equal(t, 32, ones, "second gateway route should be /32 for IPv4")
-				return nil
-			}),
+		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 		// Even with IPv6 first, SetHWAddrByIP should use both addresses
 		mockIP.EXPECT().SetHWAddrByIP(interfaceName, ipv4ContainerAddr, ipv6ContainerAddr).Return(nil),
-		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
 		mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 	)
 	configContext := newConfigureVethContext(
 		interfaceName, result, mockIP, mockIPAM, mockNetLink)
@@ -2373,6 +2388,7 @@ func TestConfigureContainerVethInterfaceDeleteDefaultRoutesIPv4(t *testing.T) {
 		Gateway: gatewayIPAddr,
 	}
 
+	mockAttrs := &netlink.LinkAttrs{Index: 1}
 	result := &current.Result{
 		IPs: []*current.IPConfig{ipConfig},
 	}
@@ -2391,12 +2407,16 @@ func TestConfigureContainerVethInterfaceDeleteDefaultRoutesIPv4(t *testing.T) {
 	routes := []netlink.Route{defaultRoute, routeWithGw}
 
 	gomock.InOrder(
+		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 		mockIP.EXPECT().SetHWAddrByIP(interfaceName, containerIPAddr, nil).Return(nil),
-		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
 		mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
 		// Only the default route (without gateway) should be deleted
 		mockNetLink.EXPECT().RouteDel(&defaultRoute).Return(nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 	)
 	configContext := newConfigureVethContext(
 		interfaceName, result, mockIP, mockIPAM, mockNetLink)
@@ -2420,6 +2440,7 @@ func TestConfigureContainerVethInterfaceDeleteDefaultRoutesIPv6(t *testing.T) {
 		},
 		Gateway: ipv6Gateway,
 	}
+	mockAttrs := &netlink.LinkAttrs{Index: 1}
 
 	result := &current.Result{
 		IPs: []*current.IPConfig{ipConfig},
@@ -2434,11 +2455,15 @@ func TestConfigureContainerVethInterfaceDeleteDefaultRoutesIPv6(t *testing.T) {
 	routes := []netlink.Route{defaultRoute}
 
 	gomock.InOrder(
+		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 		mockIP.EXPECT().SetHWAddrByIP(interfaceName, nil, ipv6ContainerAddr).Return(nil),
-		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
 		mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
 		mockNetLink.EXPECT().RouteDel(&defaultRoute).Return(nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 	)
 	configContext := newConfigureVethContext(
 		interfaceName, result, mockIP, mockIPAM, mockNetLink)
@@ -2479,6 +2504,7 @@ func TestConfigureContainerVethInterfaceDeleteDefaultRoutesBothFamilies(t *testi
 	}
 
 	mockLink := mock_netlink.NewMockLink(ctrl)
+	mockAttrs := &netlink.LinkAttrs{Index: 1}
 	// Both IPv4 and IPv6 default routes
 	ipv4DefaultRoute := netlink.Route{
 		Dst: &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)},
@@ -2491,13 +2517,21 @@ func TestConfigureContainerVethInterfaceDeleteDefaultRoutesBothFamilies(t *testi
 	routes := []netlink.Route{ipv4DefaultRoute, ipv6DefaultRoute}
 
 	gomock.InOrder(
+		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 		mockIP.EXPECT().SetHWAddrByIP(interfaceName, ipv4ContainerAddr, ipv6ContainerAddr).Return(nil),
-		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
 		mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
 		// Both default routes should be deleted
 		mockNetLink.EXPECT().RouteDel(&ipv4DefaultRoute).Return(nil),
 		mockNetLink.EXPECT().RouteDel(&ipv6DefaultRoute).Return(nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 	)
 	configContext := newConfigureVethContext(
 		interfaceName, result, mockIP, mockIPAM, mockNetLink)
@@ -2537,14 +2571,23 @@ func TestConfigureContainerVethInterfaceHWAddrIPv4Preference(t *testing.T) {
 	}
 
 	mockLink := mock_netlink.NewMockLink(ctrl)
+	mockAttrs := &netlink.LinkAttrs{Index: 1}
 	routes := []netlink.Route{}
 
 	gomock.InOrder(
+		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 		// Both IPv4 and IPv6 addresses should be passed to SetHWAddrByIP
 		mockIP.EXPECT().SetHWAddrByIP(interfaceName, ipv4ContainerAddr, ipv6ContainerAddr).Return(nil),
-		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
 		mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 	)
 	configContext := newConfigureVethContext(
 		interfaceName, result, mockIP, mockIPAM, mockNetLink)
@@ -2767,14 +2810,19 @@ func TestProperty_DefaultRouteDeletion_FamilyAllUsed(t *testing.T) {
 	}
 
 	mockLink := mock_netlink.NewMockLink(ctrl)
+	mockAttrs := &netlink.LinkAttrs{Index: 1}
 	routes := []netlink.Route{}
 
 	gomock.InOrder(
+		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 		mockIP.EXPECT().SetHWAddrByIP(interfaceName, containerIPAddr, nil).Return(nil),
-		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
 		// Verify FAMILY_ALL is used to list routes
 		mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 	)
 	configContext := newConfigureVethContext(
 		interfaceName, result, mockIP, mockIPAM, mockNetLink)
@@ -2953,20 +3001,17 @@ func TestProperty_BackwardCompatibility(t *testing.T) {
 
 			// Test 3: Veth configuration adds /32 gateway route for IPv4 (backward compatible)
 			mockLink := mock_netlink.NewMockLink(ctrl)
-			routes := []netlink.Route{}
+			mockAttrs := &netlink.LinkAttrs{Index: 1}
+					routes := []netlink.Route{}
 			gomock.InOrder(
-				mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).DoAndReturn(
-					func(ifName string, res *current.Result) error {
-						// Verify gateway route is /32 for IPv4 (backward compatible behavior)
-						assert.Equal(t, 1, len(res.Routes), "should have 1 gateway route")
-						ones, bits := res.Routes[0].Dst.Mask.Size()
-						assert.Equal(t, 32, ones, "IPv4 gateway route should be /32")
-						assert.Equal(t, 32, bits, "should be IPv4 mask")
-						return nil
-					}),
-				mockIP.EXPECT().SetHWAddrByIP(interfaceName, ipv4Addr, nil).Return(nil),
 				mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
+				mockLink.EXPECT().Attrs().Return(mockAttrs),
+				mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+				mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
+				mockIP.EXPECT().SetHWAddrByIP(interfaceName, ipv4Addr, nil).Return(nil),
 				mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
+				mockLink.EXPECT().Attrs().Return(mockAttrs),
+				mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 			)
 			configContext := newConfigureVethContext(
 				interfaceName, result, mockIP, mockIPAM, mockNetLink)
@@ -3341,23 +3386,18 @@ func TestProperty_SingleIPv6ResultProcessing_VethConfiguration(t *testing.T) {
 			}
 
 			mockLink := mock_netlink.NewMockLink(ctrl)
-			routes := []netlink.Route{}
+			mockAttrs := &netlink.LinkAttrs{Index: 1}
+					routes := []netlink.Route{}
 
 			gomock.InOrder(
-				mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).DoAndReturn(
-					func(ifName string, res *current.Result) error {
-						// Property 2: Verify /128 gateway route is added for IPv6
-						assert.Equal(t, 1, len(res.Routes), "should have 1 gateway route")
-						assert.Equal(t, ipv6Gateway.String(), res.Routes[0].Dst.IP.String(),
-							"gateway route should use IPv6 gateway")
-						ones, bits := res.Routes[0].Dst.Mask.Size()
-						assert.Equal(t, 128, ones, "IPv6 gateway route should be /128")
-						assert.Equal(t, 128, bits, "should be IPv6 mask")
-						return nil
-					}),
-				mockIP.EXPECT().SetHWAddrByIP(interfaceName, nil, ipv6ContainerAddr).Return(nil),
 				mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
-				mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
+				mockLink.EXPECT().Attrs().Return(mockAttrs),
+				mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+				mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
+				mockIP.EXPECT().SetHWAddrByIP(interfaceName, nil, ipv6ContainerAddr).Return(nil),
+			mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
+				mockLink.EXPECT().Attrs().Return(mockAttrs),
+				mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 			)
 
 			configContext := newConfigureVethContext(
@@ -3729,32 +3769,23 @@ func TestProperty_DualStackResultProcessing_VethConfiguration(t *testing.T) {
 			}
 
 			mockLink := mock_netlink.NewMockLink(ctrl)
-			routes := []netlink.Route{}
+			mockAttrs := &netlink.LinkAttrs{Index: 1}
+					routes := []netlink.Route{}
 
 			gomock.InOrder(
-				mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).DoAndReturn(
-					func(ifName string, res *current.Result) error {
-						// Property 3: Verify gateway routes for both IPv4 and IPv6
-						assert.Equal(t, 2, len(res.Routes), "should have 2 gateway routes")
-
-						// First route should be IPv4 /32
-						assert.Equal(t, ipv4Gateway.String(), res.Routes[0].Dst.IP.String(),
-							"first gateway route should use IPv4 gateway")
-						ones, _ := res.Routes[0].Dst.Mask.Size()
-						assert.Equal(t, 32, ones, "IPv4 gateway route should be /32")
-
-						// Second route should be IPv6 /128
-						assert.Equal(t, ipv6Gateway.String(), res.Routes[1].Dst.IP.String(),
-							"second gateway route should use IPv6 gateway")
-						ones, _ = res.Routes[1].Dst.Mask.Size()
-						assert.Equal(t, 128, ones, "IPv6 gateway route should be /128")
-
-						return nil
-					}),
+				mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
+				mockLink.EXPECT().Attrs().Return(mockAttrs),
+				mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+				mockLink.EXPECT().Attrs().Return(mockAttrs),
+				mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+				mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 				// For dual-stack, SetHWAddrByIP uses both IPv4 and IPv6 addresses
 				mockIP.EXPECT().SetHWAddrByIP(interfaceName, ipv4ContainerAddr, ipv6ContainerAddr).Return(nil),
-				mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
-				mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
+			mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
+				mockLink.EXPECT().Attrs().Return(mockAttrs),
+				mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+				mockLink.EXPECT().Attrs().Return(mockAttrs),
+				mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 			)
 
 			configContext := newConfigureVethContext(
@@ -3800,6 +3831,7 @@ func TestProperty_DualStackResultProcessing_DefaultRoutesDeletion(t *testing.T) 
 	}
 
 	mockLink := mock_netlink.NewMockLink(ctrl)
+		mockAttrs := &netlink.LinkAttrs{Index: 1}
 
 	// Both IPv4 and IPv6 default routes present
 	ipv4DefaultRoute := netlink.Route{
@@ -3813,13 +3845,21 @@ func TestProperty_DualStackResultProcessing_DefaultRoutesDeletion(t *testing.T) 
 	routes := []netlink.Route{ipv4DefaultRoute, ipv6DefaultRoute}
 
 	gomock.InOrder(
+		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 		mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 		mockIP.EXPECT().SetHWAddrByIP(interfaceName, ipv4ContainerAddr, ipv6ContainerAddr).Return(nil),
-		mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
 		mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
 		// Property 3: Both default routes should be deleted
 		mockNetLink.EXPECT().RouteDel(&ipv4DefaultRoute).Return(nil),
 		mockNetLink.EXPECT().RouteDel(&ipv6DefaultRoute).Return(nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
+		mockLink.EXPECT().Attrs().Return(mockAttrs),
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 	)
 
 	configContext := newConfigureVethContext(


### PR DESCRIPTION
…ask, via the bridge.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
There are 4 changes in this PR for the bridge, that allow to setup a route from a replica task to the daemon task, via the bridge.


### Implementation details
<!-- How are the changes implemented? -->
1. Bridge /22 Mask for LinkLocal IPs. Link-local IPs (169.254.x.x) need /22 mask on bridge to cover the entire ECS subnet (169.254.172.0/22), allowing proper routing.
2. On-Link Gateway Routes - With /32 mask, the gateway (169.254.172.1) is not in the same subnet as the daemon container IP (169.254.172.2/32). An on-link route tells the kernel that this gateway is directly reachable even though it's not in my subnet.
3. Connected Subnet Routes - Tells the kernel "to reach the entire 169.254.172.0/22 subnet, use this interface with this source IP". This enables proper routing for the connected network.
4. Default Route Deletion Logic would delete the on-link gateway routes we just added, hence had to add logic to preserve the routes we added. 
### Testing
<!-- How was this tested? -->
UTs and created an AMI with the ecs-agent changes - would delete the on-link gateway routes we just added.
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
