### PR TITLE
IPv6 uniqie ID fix.

### DIFF
--- a/plugins/ipam/commands/commands.go
+++ b/plugins/ipam/commands/commands.go
@@ -352,7 +352,9 @@ func getIPV6Address(ipManager ipstore.IPAllocator, conf *config.IPAMConfig) (*ne
 		// if this ip has already been used, it will return an error
 		// IPv6 addresses are stored with the "6" prefix in the database
 		ipKey := ipstore.IPPrefixV6 + assignedAddress.IP.String()
-		err := ipManager.Assign(ipKey, conf.ID)
+		// Append "-v6" to the ID to make it unique from IPv4 allocations
+		idV6 := conf.ID + "-v6"
+		err := ipManager.Assign(ipKey, idV6)
 		if err != nil {
 			return nil, errors.Wrapf(err, "getIPV6Address commands: failed to mark this ip %v as used", assignedAddress)
 		}

--- a/plugins/ipam/commands/commands_test.go
+++ b/plugins/ipam/commands/commands_test.go
@@ -355,7 +355,7 @@ func TestGetSpecificIPV6HappyPath(t *testing.T) {
 	conf, allocator := setupIPv6("2001:db8::/64", "2001:db8::3/64", "", t)
 
 	gomock.InOrder(
-		allocator.EXPECT().Assign(ipstore.IPPrefixV6+conf.IPV6Address.IP.String(), gomock.Any()).Return(nil),
+		allocator.EXPECT().Assign(ipstore.IPPrefixV6+conf.IPV6Address.IP.String(), conf.ID+"-v6").Return(nil),
 	)
 
 	assignedAddress, err := getIPV6Address(allocator, conf)
@@ -383,7 +383,7 @@ func TestGetNextIPV6HappyPath(t *testing.T) {
 func TestGetUsedIPv6(t *testing.T) {
 	conf, allocator := setupIPv6("2001:db8::/64", "2001:db8::3/64", "", t)
 
-	allocator.EXPECT().Assign(ipstore.IPPrefixV6+conf.IPV6Address.IP.String(), gomock.Any()).Return(errors.New("IP has already been used"))
+	allocator.EXPECT().Assign(ipstore.IPPrefixV6+conf.IPV6Address.IP.String(), conf.ID+"-v6").Return(errors.New("IP has already been used"))
 
 	assignedAddress, err := getIPV6Address(allocator, conf)
 	assert.Error(t, err, "assign a used IPv6 ip should cause error")
@@ -396,7 +396,7 @@ func TestAddIPv6OnlyHappyPath(t *testing.T) {
 
 	gomock.InOrder(
 		allocator.EXPECT().Get(ipstore.IPPrefixV6+conf.IPV6Gateway.String()).Return(config.GatewayV6Value, nil),
-		allocator.EXPECT().Assign(ipstore.IPPrefixV6+conf.IPV6Address.IP.String(), gomock.Any()).Return(nil),
+		allocator.EXPECT().Assign(ipstore.IPPrefixV6+conf.IPV6Address.IP.String(), conf.ID+"-v6").Return(nil),
 		allocator.EXPECT().Update(ipstore.LastKnownIPv6Key, conf.IPV6Address.IP.String()).Return(nil),
 	)
 
@@ -417,7 +417,7 @@ func TestAddDualStackHappyPath(t *testing.T) {
 		allocator.EXPECT().Update(config.LastKnownIPKey, conf.IPV4Address.IP.String()).Return(nil),
 		// IPv6 handling
 		allocator.EXPECT().Get(ipstore.IPPrefixV6+conf.IPV6Gateway.String()).Return(config.GatewayV6Value, nil),
-		allocator.EXPECT().Assign(ipstore.IPPrefixV6+conf.IPV6Address.IP.String(), gomock.Any()).Return(nil),
+		allocator.EXPECT().Assign(ipstore.IPPrefixV6+conf.IPV6Address.IP.String(), conf.ID+"-v6").Return(nil),
 		allocator.EXPECT().Update(ipstore.LastKnownIPv6Key, conf.IPV6Address.IP.String()).Return(nil),
 	)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
When allocating both IPv4 and IPv6 addresses for the same task using the IPAM plugin, the plugin uses the same conf.ID for both allocations. This causes a conflict in the IP allocation database because:

1. IPv4 allocation calls ipManager.Assign(ipKey, conf.ID) 
2. IPv6 allocation also calls ipManager.Assign(ipKey, conf.ID) with the same ID
3. The IPAM store treats these as duplicate allocations for the same resource, leading to allocation failures or incorrect state tracking

This issue manifests in dual-stack (IPv4 + IPv6) task configurations where tasks need both address families assigned simultaneously.

Fix is to append a unique suffix to the configuration ID when allocating IPv6 addresses. This ensures IPv6 allocations are tracked separately from IPv4 allocations in the IPAM database, preventing ID conflicts while maintaining the relationship between the two allocations through the shared base ID.

### Testing
Tested with a custom AMI. IPv6 and IPv4 tasks works fine. Same for daemons. Also tested egress on daemons, with static IP and routing via bridge. 

New tests cover the changes: UTs updated.

### Description for the changelog
IPv6 uniqie ID fix.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
