### PR TITLE
IPv6 daemon egress fixes.

### DIFF
--- a/plugins/ecs-bridge/engine/bridge_static_ip_test.go
+++ b/plugins/ecs-bridge/engine/bridge_static_ip_test.go
@@ -155,6 +155,49 @@ func TestConfigureBridge_NonLinkLocalIP_UsesContainerMask(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestConfigureBridge_IPv6ULA_UsesCIDR112 tests that bridge gets /112 mask for IPv6 ULA (daemon bridge)
+func TestConfigureBridge_IPv6ULA_UsesCIDR112(t *testing.T) {
+	ctrl, _, mockNetLink, _, _, _ := setup(t)
+	defer ctrl.Finish()
+
+	bridgeLink := &netlink.Bridge{
+		LinkAttrs: netlink.LinkAttrs{Name: "fargate-bridge"},
+	}
+
+	// IPv6 ULA gateway (daemon bridge)
+	gatewayIP := net.ParseIP("fd00:ec2::172:1")
+	containerIP := net.ParseIP("fd00:ec2::172:2")
+
+	ipConfig := &current.IPConfig{
+		Address: net.IPNet{
+			IP:   containerIP,
+			Mask: net.CIDRMask(128, 128), // Container has /128
+		},
+		Gateway: gatewayIP,
+	}
+
+	result := &current.Result{
+		IPs: []*current.IPConfig{ipConfig},
+	}
+
+	// Expected bridge address should have /112 mask
+	expectedBridgeAddr := &netlink.Addr{
+		IPNet: &net.IPNet{
+			IP:   gatewayIP,
+			Mask: net.CIDRMask(112, 128), // Bridge gets /112 for ULA
+		},
+	}
+
+	gomock.InOrder(
+		mockNetLink.EXPECT().AddrList(bridgeLink, syscall.AF_INET6).Return(nil, nil),
+		mockNetLink.EXPECT().AddrAdd(bridgeLink, expectedBridgeAddr).Return(nil),
+	)
+
+	engine := &engine{netLink: mockNetLink}
+	err := engine.ConfigureBridge(result, bridgeLink)
+	assert.NoError(t, err)
+}
+
 // TestConfigureBridge_BeforeContainer tests that bridge is configured before container
 // This is important because container configuration adds routes to the gateway,
 // which must already exist on the bridge
@@ -227,10 +270,10 @@ func TestConfigureVeth_AddsOnLinkGatewayRoute(t *testing.T) {
 	assert.Equal(t, net.CIDRMask(32, 32).String(), capturedGatewayRoute.Dst.Mask.String())
 	assert.Equal(t, netlink.SCOPE_LINK, capturedGatewayRoute.Scope)
 
-	// Verify subnet route
+	// Verify subnet route uses /22 mask (connected subnet) not /32 (container address)
 	assert.NotNil(t, capturedSubnetRoute)
-	assert.Equal(t, containerIP.String(), capturedSubnetRoute.Dst.IP.String())
-	assert.Equal(t, net.CIDRMask(32, 32).String(), capturedSubnetRoute.Dst.Mask.String())
+	assert.Equal(t, "169.254.172.0", capturedSubnetRoute.Dst.IP.String())
+	assert.Equal(t, net.CIDRMask(22, 32).String(), capturedSubnetRoute.Dst.Mask.String())
 	assert.Equal(t, netlink.SCOPE_LINK, capturedSubnetRoute.Scope)
 }
 
@@ -354,10 +397,10 @@ func TestConfigureVeth_AddsConnectedSubnetRoute(t *testing.T) {
 	err := configContext.run(nil)
 	assert.NoError(t, err)
 
-	// Verify subnet route
+	// Verify subnet route uses /22 mask (connected subnet) not /32 (container address)
 	assert.NotNil(t, capturedSubnetRoute)
-	assert.Equal(t, containerIP.String(), capturedSubnetRoute.Dst.IP.String())
-	assert.Equal(t, net.CIDRMask(32, 32).String(), capturedSubnetRoute.Dst.Mask.String())
+	assert.Equal(t, "169.254.172.0", capturedSubnetRoute.Dst.IP.String())
+	assert.Equal(t, net.CIDRMask(22, 32).String(), capturedSubnetRoute.Dst.Mask.String())
 	assert.Equal(t, netlink.SCOPE_LINK, capturedSubnetRoute.Scope)
 }
 

--- a/plugins/ecs-bridge/engine/configureveth.go
+++ b/plugins/ecs-bridge/engine/configureveth.go
@@ -186,15 +186,29 @@ func (configContext *configureVethContext) run(hostNS ns.NetNS) error {
 			continue
 		}
 		
-		// Calculate the subnet network address using the IP's mask
-		subnetIP := ipConfig.Address.IP.Mask(ipConfig.Address.Mask)
+		// Determine the correct subnet mask size based on IP version
+		var subnetMaskSize int
+		var totalBits int
+		if ipConfig.Address.IP.To4() != nil {
+			subnetMaskSize = configContext.connectedSubnetMaskSizeIPv4
+			totalBits = 32
+		} else {
+			subnetMaskSize = configContext.connectedSubnetMaskSizeIPv6
+			totalBits = 128
+		}
+		
+		// Create subnet mask using the connected subnet mask size
+		subnetMask := net.CIDRMask(subnetMaskSize, totalBits)
+		
+		// Calculate the subnet network address using the connected subnet mask
+		subnetIP := ipConfig.Address.IP.Mask(subnetMask)
 		
 		// Add the connected subnet route
 		subnetRoute := &netlink.Route{
 			LinkIndex: link.Attrs().Index,
 			Dst: &net.IPNet{
 				IP:   subnetIP,
-				Mask: ipConfig.Address.Mask,
+				Mask: subnetMask,
 			},
 			Scope: netlink.SCOPE_LINK,
 		}

--- a/plugins/ecs-bridge/engine/engine.go
+++ b/plugins/ecs-bridge/engine/engine.go
@@ -306,6 +306,10 @@ func (engine *engine) ConfigureBridge(result *current.Result, bridge *netlink.Br
 			// IPv6 link-local - use /64
 			bridgeMask = net.CIDRMask(64, 128)
 			log.Infof("Applying /64 mask to IPv6 link-local gateway")
+		} else if ipConfig.Gateway.To4() == nil && len(ipConfig.Gateway) == 16 && ipConfig.Gateway[0] == 0xfd {
+			// IPv6 ULA (fd00::/8) - daemon bridge - use /112
+			bridgeMask = net.CIDRMask(112, 128)
+			log.Infof("Applying /112 mask to IPv6 ULA daemon bridge gateway")
 		}
 
 		resultBridgeNetwork := &net.IPNet{

--- a/plugins/ecs-bridge/engine/engine_test.go
+++ b/plugins/ecs-bridge/engine/engine_test.go
@@ -2113,7 +2113,7 @@ func TestProperty_BridgeAddressAssignment_GatewayUsedAsBridgeAddress(t *testing.
 		{
 			name:    "IPv6 gateway becomes bridge address",
 			gateway: net.ParseIP("fd00::1"),
-			mask:    net.CIDRMask(64, 128),
+			mask:    net.CIDRMask(112, 128),
 			family:  syscall.AF_INET6,
 		},
 	}
@@ -3279,22 +3279,25 @@ func TestProperty_SingleIPv6ResultProcessing(t *testing.T) {
 // Property 2: Single IPv6 Result Processing
 func TestProperty_SingleIPv6ResultProcessing_BridgeConfiguration(t *testing.T) {
 	testCases := []struct {
-		name        string
-		ipv6Address string
-		ipv6Gateway string
-		maskBits    int
+		name            string
+		ipv6Address     string
+		ipv6Gateway     string
+		maskBits        int
+		expectedMaskBits int // mask applied by ConfigureBridge (may differ for ULA)
 	}{
 		{
-			name:        "global unicast IPv6",
-			ipv6Address: "2001:db8::2",
-			ipv6Gateway: "2001:db8::1",
-			maskBits:    64,
+			name:            "global unicast IPv6",
+			ipv6Address:     "2001:db8::2",
+			ipv6Gateway:     "2001:db8::1",
+			maskBits:        64,
+			expectedMaskBits: 64,
 		},
 		{
-			name:        "unique local address",
-			ipv6Address: "fd00:ec2::2",
-			ipv6Gateway: "fd00:ec2::1",
-			maskBits:    64,
+			name:            "unique local address",
+			ipv6Address:     "fd00:ec2::2",
+			ipv6Gateway:     "fd00:ec2::1",
+			maskBits:        64,
+			expectedMaskBits: 112, // ULA gets /112 mask
 		},
 	}
 
@@ -3321,7 +3324,7 @@ func TestProperty_SingleIPv6ResultProcessing_BridgeConfiguration(t *testing.T) {
 			bridgeAddr := &netlink.Addr{
 				IPNet: &net.IPNet{
 					IP:   ipv6Gateway,
-					Mask: net.CIDRMask(tc.maskBits, 128),
+					Mask: net.CIDRMask(tc.expectedMaskBits, 128),
 				},
 			}
 
@@ -3618,31 +3621,34 @@ func TestProperty_DualStackResultProcessing_IPv6First(t *testing.T) {
 // Property 3: Dual-Stack Result Processing
 func TestProperty_DualStackResultProcessing_BridgeConfiguration(t *testing.T) {
 	testCases := []struct {
-		name         string
-		ipv4Address  string
-		ipv4Gateway  string
-		ipv4MaskBits int
-		ipv6Address  string
-		ipv6Gateway  string
-		ipv6MaskBits int
+		name                 string
+		ipv4Address          string
+		ipv4Gateway          string
+		ipv4MaskBits         int
+		ipv6Address          string
+		ipv6Gateway          string
+		ipv6MaskBits         int
+		expectedIPv6MaskBits int // mask applied by ConfigureBridge (may differ for ULA)
 	}{
 		{
-			name:         "standard dual-stack",
-			ipv4Address:  "192.168.1.2",
-			ipv4Gateway:  "192.168.1.1",
-			ipv4MaskBits: 24,
-			ipv6Address:  "2001:db8::2",
-			ipv6Gateway:  "2001:db8::1",
-			ipv6MaskBits: 64,
+			name:                 "standard dual-stack",
+			ipv4Address:          "192.168.1.2",
+			ipv4Gateway:          "192.168.1.1",
+			ipv4MaskBits:         24,
+			ipv6Address:          "2001:db8::2",
+			ipv6Gateway:          "2001:db8::1",
+			ipv6MaskBits:         64,
+			expectedIPv6MaskBits: 64,
 		},
 		{
-			name:         "ECS dual-stack",
-			ipv4Address:  "169.254.172.2",
-			ipv4Gateway:  "169.254.172.1",
-			ipv4MaskBits: 22,
-			ipv6Address:  "fd00:ec2::2",
-			ipv6Gateway:  "fd00:ec2::1",
-			ipv6MaskBits: 64,
+			name:                 "ECS dual-stack",
+			ipv4Address:          "169.254.172.2",
+			ipv4Gateway:          "169.254.172.1",
+			ipv4MaskBits:         22,
+			ipv6Address:          "fd00:ec2::2",
+			ipv6Gateway:          "fd00:ec2::1",
+			ipv6MaskBits:         64,
+			expectedIPv6MaskBits: 112, // ULA gets /112 mask
 		},
 	}
 
@@ -3683,7 +3689,7 @@ func TestProperty_DualStackResultProcessing_BridgeConfiguration(t *testing.T) {
 			ipv6BridgeAddr := &netlink.Addr{
 				IPNet: &net.IPNet{
 					IP:   ipv6Gateway,
-					Mask: net.CIDRMask(tc.ipv6MaskBits, 128),
+					Mask: net.CIDRMask(tc.expectedIPv6MaskBits, 128),
 				},
 			}
 


### PR DESCRIPTION

## IPv6 Daemon-Bridge Networking Fixes

### Problem

On IPv6-only ECS instances, awsvpc tasks cannot communicate with daemon tasks via the fargate-bridge using IPv6. Three issues prevent this:

1. Awsvpc tasks are not assigned an IPv6 address on the fargate-bridge
2. The bridge gateway gets a /128 mask for IPv6 ULA addresses instead of /112
3. Connected subnet routes use the container's address mask (/128) instead of the subnet mask (/112)

### Background: Why ULA instead of Link-Local for IPv6

IPv4 daemon-bridge communication uses link-local addresses (169.254.172.x). This works because only the fargate-bridge interface has a 169.254.x.x address, so the kernel unambiguously routes to it.

For IPv6, link-local (fe80::) cannot be used because every interface has an fe80:: address. The kernel cannot determine which interface to route through:

### IPv6 link-local is ambiguous
$ ip -6 route get fe80::1                                                                                                                                                                                                                                                                                                                                                   
fe80::1 from :: dev eth0    ← WRONG, should go to fargate-bridge                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                            
### IPv6 ULA is unambiguous (only fargate-bridge has fd00:ec2::)                                                                                                                                                                                                                                                                                                              
$ ip -6 route get fd00:ec2::172:2                                                                                                                                                                                                                                                                                                                                           
fd00:ec2::172:2 from :: dev fargate-bridge    ← CORRECT                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                            
### IPv4 link-local is unambiguous (only fargate-bridge has 169.254.x.x)                                                                                                                                                                                                                                                                                                      
$ ip route get 169.254.172.2                                                                                                                                                                                                                                                                                                                                                
169.254.172.2 dev fargate-bridge    ← CORRECT                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                            

ULA (fd00:ec2::/112) gives the same "only one interface" property as IPv4 link-local.

### Bridge IP Allocation

| Component | IPv4 | IPv6 (ULA) |
|-----------|------|------------|
| Bridge gateway | 169.254.172.1/22 | fd00:ec2::172:1/112 |
| Daemon task | 169.254.172.2/32 | fd00:ec2::172:2/128 |
| Awsvpc task | 169.254.172.3/32 | fd00:ec2::172:3/128 |

### Fix 1: Add IPv6 subnet to awsvpc bridge IPAM config (ECS Agent) - https://github.com/aws/amazon-ecs-agent/pull/4888

File: ecs-agent/netlib/platform/cniconf_linux.go (+1 line)

createBridgePluginConfig() (for awsvpc tasks) only configured IPV4Subnet. Without an IPv6 subnet, the IPAM plugin never assigns an IPv6 address to the awsvpc task's eth0 on the fargate-bridge. Note that createDaemonBridgePluginConfig() already had full IPv6 config — this was only missing from the awsvpc path.

Fix: Add IPV6Subnet: ECSSubNetIPv6 (fd00:ec2::172:0/112) to the IPAM config.

Before: Awsvpc task eth0 on fargate-bridge has only 169.254.172.3/22 (IPv4).
After: Awsvpc task eth0 has 169.254.172.3/22 (IPv4) + fd00:ec2::172:X/112 (IPv6).

### Fix 2: Apply /112 mask to IPv6 ULA bridge gateway (CNI Plugin)

File: plugins/ecs-bridge/engine/engine.go (+4 lines in ConfigureBridge)

When ConfigureBridge assigns the gateway IP to the bridge interface, it determines the subnet mask based on address type. The existing code handled:
- IPv4 link-local (169.254.x.x) → /22
- IPv6 link-local (fe80::) → /64

But NOT IPv6 ULA (fd00::). Without this, the bridge gateway got /128 (single IP) and couldn't route to other IPs in the subnet.

Fix: Add ULA detection (ipConfig.Gateway[0] == 0xfd) to apply /112:
go
} else if ipConfig.Gateway.To4() == nil && len(ipConfig.Gateway) == 16 && ipConfig.Gateway[0] == 0xfd {
    bridgeMask = net.CIDRMask(112, 128)                                                                                                                                                                                                                                                                                                                                     
}                                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                            

Before: Bridge has fd00:ec2::172:1/128.
After: Bridge has fd00:ec2::172:1/112.

### Fix 3: Use connected subnet mask for route creation (CNI Plugin)

File: plugins/ecs-bridge/engine/configureveth.go

When adding the connected subnet route inside a container, the original code used the container's address mask:
go
subnetIP := ipConfig.Address.IP.Mask(ipConfig.Address.Mask)  // /128 or /32
Mask: ipConfig.Address.Mask,                                  // /128 or /32                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                            

For daemon at fd00:ec2::172:2/128, this creates route fd00:ec2::172:2/128 — a single-IP route. The container can only reach its own IP, not the awsvpc task at .3.

Fix: Use connectedSubnetMaskSize (22 for IPv4, 112 for IPv6) instead of the container's address mask:
go
subnetMask := net.CIDRMask(subnetMaskSize, totalBits)  // /22 or /112
subnetIP := ipConfig.Address.IP.Mask(subnetMask)                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                            

Before: Route fd00:ec2::172:2/128 (single IP) and 169.254.172.2/32 (single IP).
After: Route fd00:ec2::172:0/112 (whole IPv6 subnet) and 169.254.172.0/22 (whole IPv4 subnet).

### Verified Routes

Daemon task (IPv4 instance):
default via 169.254.172.1 dev eth0       # Egress via bridge gateway
blackhole 169.254.169.254                # IMDS blocked                                                                                                                                                                                                                                                                                                                     
169.254.170.2 via 169.254.172.1 dev eth0 # TMDS via gateway                                                                                                                                                                                                                                                                                                                 
169.254.172.0/22 dev eth0 scope link     # Connected subnet (can reach awsvpc at .3)                                                                                                                                                                                                                                                                                        
169.254.172.1 dev eth0 scope link        # Gateway host route                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                            

Awsvpc task (IPv4 instance):
default via 10.194.20.1 dev eth1                                  # Internet via task ENI
10.194.20.0/24 dev eth1 proto kernel scope link src 10.194.20.37  # VPC subnet                                                                                                                                                                                                                                                                                              
blackhole 169.254.169.254                                         # IMDS blocked                                                                                                                                                                                                                                                                                            
169.254.170.2 via 169.254.172.1 dev eth0                          # TMDS via bridge gateway                                                                                                                                                                                                                                                                                 
169.254.172.0/22 dev eth0 proto kernel scope link src 169.254.172.3  # Connected subnet (can reach daemon at .2)                                                                                                                                                                                                                                                            
169.254.172.1 dev eth0 scope link                                 # Gateway host route                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                            

Awsvpc task IPv6 routes (IPv6-only instance):
fd00:ec2::172:1 dev eth0 metric 1024 pref medium                 # Gateway host route
fd00:ec2::172:0/112 dev eth0 proto kernel metric 256 pref medium  # Connected subnet (can reach daemon at ::172:2)                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                            

### Verification
- **IPv6-only instance:** Awsvpc task successfully curls daemon at http://[fd00:ec2::172:2]:8080 → "Hello from daemon!" ✅
- **IPv4 instance:** Daemon and awsvpc tasks have correct routes, no regression ✅
- **All unit tests pass** ✅

### Description for the changelog
IPv6 Daemon-Bridge Networking Fixes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
