### PR TITLE
fix(ecs-bridge): Make BlockInstanceMetadata idempotent for EEXIST

### DIFF
--- a/plugins/ecs-bridge/e2eTests/e2e_test.go
+++ b/plugins/ecs-bridge/e2eTests/e2e_test.go
@@ -2184,3 +2184,176 @@ func TestDaemonHostNamespace(t *testing.T) {
 		t.Log("Dual-stack daemon host namespace test completed successfully")
 	})
 }
+
+// TestAddBridgeAfterDeletion validates that a bridge can be successfully re-created
+// after it has been deleted. This simulates the daemon task restart scenario where
+// the namespace persists but the bridge was removed, and the CNI plugin needs to
+// recreate it from scratch.
+func TestAddBridgeAfterDeletion(t *testing.T) {
+	// Skip if instance doesn't support IPv4
+	skipIfNoIPv4(t)
+
+	// Ensure that the bridge plugin exists
+	bridgePluginPath, err := invoke.FindInPath("ecs-bridge", []string{os.Getenv("CNI_PATH")})
+	require.NoError(t, err, "Unable to find bridge plugin in path")
+
+	// Create a directory for storing test logs
+	testLogDir, err := ioutil.TempDir("", "ecs-bridge-e2e-test-readd-")
+	require.NoError(t, err, "Unable to create directory for storing test logs")
+
+	os.Setenv("ECS_CNI_LOG_FILE", fmt.Sprintf("%s/bridge.log", testLogDir))
+	t.Logf("Using %s for test logs", testLogDir)
+	defer os.Unsetenv("ECS_CNI_LOG_FILE")
+
+	ok, err := strconv.ParseBool(getEnvOrDefault("ECS_PRESERVE_E2E_TEST_LOGS", "false"))
+	assert.NoError(t, err, "Unable to parse ECS_PRESERVE_E2E_TEST_LOGS env var")
+	defer func(preserve bool) {
+		if !t.Failed() && !preserve {
+			os.RemoveAll(testLogDir)
+		}
+	}(ok)
+
+	// Create a network namespace to execute the test in.
+	// This namespace persists across ADD/DEL/ADD cycles (like a daemon netns).
+	testNS, err := ns.NewNS()
+	require.NoError(t, err, "Unable to create the network namespace to run the test in")
+	defer testNS.Close()
+
+	// Create a directory to store IPAM db
+	ipamDir, err := ioutil.TempDir("", "ecs-ipam-readd-")
+	require.NoError(t, err, "Unable to create a temp directory for the ipam db")
+	os.Setenv("IPAM_DB_PATH", fmt.Sprintf("%s/ipam.db", ipamDir))
+	defer os.Unsetenv("IPAM_DB_PATH")
+	ok, err = strconv.ParseBool(getEnvOrDefault("ECS_BRIDGE_PRESERVE_IPAM_DB", "false"))
+	assert.NoError(t, err, "Unable to parse ECS_BRIDGE_PRESERVE_IPAM_DB env var")
+	if !ok {
+		defer os.RemoveAll(ipamDir)
+	}
+
+	// --- First ADD: create the bridge and veth pair ---
+	targetNS1, err := ns.NewNS()
+	require.NoError(t, err, "Unable to create the first target network namespace")
+	defer targetNS1.Close()
+
+	execInvokeArgs := &invoke.Args{
+		ContainerID: containerID,
+		NetNS:       targetNS1.Path(),
+		IfName:      ifName,
+		Path:        os.Getenv("CNI_PATH"),
+	}
+
+	testNS.Do(func(ns.NetNS) error {
+		execInvokeArgs.Command = "ADD"
+		_, err := invoke.ExecPluginWithResult(
+			bridgePluginPath,
+			[]byte(fmt.Sprintf(netConf, bridgeName, dst)),
+			execInvokeArgs)
+		require.NoError(t, err, "First ADD command failed")
+
+		// Validate bridge was created
+		bridge := getBridgeLink(t)
+		validateBridgeAddress(t, bridge)
+		t.Log("First ADD succeeded: bridge created")
+		return nil
+	})
+
+	// --- DEL: remove the veth pair (bridge remains) ---
+	testNS.Do(func(ns.NetNS) error {
+		execInvokeArgs.Command = "DEL"
+		err := invoke.ExecPluginWithoutResult(
+			bridgePluginPath,
+			[]byte(fmt.Sprintf(netConf, bridgeName, dst)),
+			execInvokeArgs)
+		require.NoError(t, err, "DEL command failed")
+		t.Log("DEL succeeded: veth removed")
+		return nil
+	})
+
+	// --- Delete the bridge explicitly to simulate full teardown ---
+	testNS.Do(func(ns.NetNS) error {
+		bridge, err := netlink.LinkByName(bridgeName)
+		require.NoError(t, err, "Bridge should still exist after DEL")
+
+		err = netlink.LinkDel(bridge)
+		require.NoError(t, err, "Unable to delete bridge")
+
+		// Confirm bridge is gone
+		_, err = netlink.LinkByName(bridgeName)
+		require.Error(t, err, "Bridge should not exist after explicit deletion")
+		t.Log("Bridge explicitly deleted")
+		return nil
+	})
+
+	// --- Second ADD: re-create the bridge in the same namespace ---
+	targetNS2, err := ns.NewNS()
+	require.NoError(t, err, "Unable to create the second target network namespace")
+	defer targetNS2.Close()
+
+	execInvokeArgs2 := &invoke.Args{
+		ContainerID: "contain-er-2",
+		NetNS:       targetNS2.Path(),
+		IfName:      ifName,
+		Path:        os.Getenv("CNI_PATH"),
+	}
+
+	var vethTestNetNS netlink.Link
+	testNS.Do(func(ns.NetNS) error {
+		execInvokeArgs2.Command = "ADD"
+		_, err := invoke.ExecPluginWithResult(
+			bridgePluginPath,
+			[]byte(fmt.Sprintf(netConf, bridgeName, dst)),
+			execInvokeArgs2)
+		require.NoError(t, err, "Second ADD command failed: unable to re-create bridge after deletion")
+
+		// Validate bridge was re-created with the expected address
+		bridge := getBridgeLink(t)
+		validateBridgeAddress(t, bridge)
+
+		// Validate that veth pair device was created
+		vethTestNetNS, ok = getVethAndVerifyLo(t)
+		require.True(t, ok, "veth device not found in test netns after second ADD")
+		t.Log("Second ADD succeeded: bridge re-created after deletion")
+		return nil
+	})
+
+	var vethTargetNetNS netlink.Link
+	targetNS2.Do(func(ns.NetNS) error {
+		// Validate the container end of the veth pair
+		vethTargetNetNS, ok = getVethAndVerifyLo(t)
+		require.True(t, ok, "veth device not found in target netns after second ADD")
+		// Validate the veth has an IPv4 address from the expected subnet (169.254.172.0/22)
+		// Note: we don't check for a specific IP because the IPAM may allocate a
+		// different address on the second ADD (the first allocation is still in the DB)
+		addrs, err := netlink.AddrList(vethTargetNetNS, netlink.FAMILY_V4)
+		require.NoError(t, err, "Unable to list addresses of veth in target netns")
+		addrFound := false
+		_, expectedSubnet, _ := net.ParseCIDR("169.254.172.0/22")
+		for _, addr := range addrs {
+			if expectedSubnet.Contains(addr.IP) {
+				addrFound = true
+				t.Logf("Veth assigned address: %s", addr.IPNet.String())
+			}
+		}
+		require.True(t, addrFound, "Veth should have an IPv4 address from 169.254.172.0/22 subnet")
+		return nil
+	})
+
+	// --- Final DEL: clean up ---
+	testNS.Do(func(ns.NetNS) error {
+		execInvokeArgs2.Command = "DEL"
+		err := invoke.ExecPluginWithoutResult(
+			bridgePluginPath,
+			[]byte(fmt.Sprintf(netConf, bridgeName, dst)),
+			execInvokeArgs2)
+		require.NoError(t, err, "Final DEL command failed")
+
+		validateLinkDoesNotExist(t, vethTestNetNS.Attrs().Name)
+		t.Log("Final DEL succeeded: cleanup complete")
+		return nil
+	})
+
+	targetNS2.Do(func(ns.NetNS) error {
+		validateLinkDoesNotExist(t, vethTargetNetNS.Attrs().Name)
+		return nil
+	})
+}

--- a/plugins/ecs-bridge/engine/engine.go
+++ b/plugins/ecs-bridge/engine/engine.go
@@ -16,6 +16,7 @@ package engine
 import (
 	"crypto/rand"
 	"net"
+	"os"
 	"strings"
 	"syscall"
 
@@ -389,7 +390,7 @@ func (engine *engine) DeleteVeth(netnsName string, interfaceName string) error {
 // BlockInstanceMetadata adds blackhole routes to block access to IMDS endpoints
 func (engine *engine) BlockInstanceMetadata(netnsName string) error {
 	log.Infof("Blocking instance metadata access for namespace: %s", netnsName)
-	
+
 	blockContext := &blockIMDSContext{
 		netLink: engine.netLink,
 	}
@@ -409,24 +410,32 @@ type blockIMDSContext struct {
 
 func (ctx *blockIMDSContext) run(_ ns.NetNS) error {
 	log.Infof("Adding blackhole routes for IMDS endpoints: %v", InstanceMetadataEndpoints)
-	
+
 	for _, ep := range InstanceMetadataEndpoints {
 		_, imdsNetwork, err := net.ParseCIDR(ep)
 		if err != nil {
 			// This should never happen as these IP addresses are hardcoded.
 			return errors.Wrapf(err, "blockIMDS engine: unable to parse instance metadata endpoint")
 		}
-		
+
 		log.Debugf("Adding blackhole route for IMDS endpoint: %s", ep)
-		
+
 		if err = ctx.netLink.RouteAdd(&netlink.Route{
 			Dst:  imdsNetwork,
 			Type: syscall.RTN_BLACKHOLE,
 		}); err != nil {
+			// If the route already exists, treat it as success since the
+			// desired state (IMDS blocked) is already achieved. This makes
+			// the operation idempotent for daemon network namespaces that
+			// persist across task restarts.
+			if os.IsExist(err) {
+				log.Infof("Blackhole route for %s already exists, skipping", ep)
+				continue
+			}
 			log.Errorf("Failed to add blackhole route for %s: %v", ep, err)
 			return errors.Wrapf(err, "blockIMDS engine: unable to add route to block instance metadata")
 		}
-		
+
 		log.Infof("Successfully added blackhole route for IMDS endpoint: %s", ep)
 	}
 	return nil

--- a/plugins/ecs-bridge/engine/engine_test.go
+++ b/plugins/ecs-bridge/engine/engine_test.go
@@ -18,6 +18,7 @@ package engine
 
 import (
 	"net"
+	"os"
 	"syscall"
 	"testing"
 
@@ -638,15 +639,15 @@ func TestConfigureContainerVethInterfaceConfigureIfaceError(t *testing.T) {
 			},
 		},
 	}
-	
+
 	link := &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: interfaceName, Index: 1}}
-	
+
 	gomock.InOrder(
 		mockNetLink.EXPECT().LinkByName(interfaceName).Return(link, nil),
 		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 		mockIPAM.EXPECT().ConfigureIface(interfaceName, result).Return(errors.New("error")),
 	)
-	
+
 	configContext := newConfigureVethContext(
 		interfaceName, result, mockIP, mockIPAM, mockNetLink, 22, 0)
 	err = configContext.run(nil)
@@ -3002,7 +3003,7 @@ func TestProperty_BackwardCompatibility(t *testing.T) {
 			// Test 3: Veth configuration adds /32 gateway route for IPv4 (backward compatible)
 			mockLink := mock_netlink.NewMockLink(ctrl)
 			mockAttrs := &netlink.LinkAttrs{Index: 1}
-					routes := []netlink.Route{}
+			routes := []netlink.Route{}
 			gomock.InOrder(
 				mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
 				mockLink.EXPECT().Attrs().Return(mockAttrs),
@@ -3279,24 +3280,24 @@ func TestProperty_SingleIPv6ResultProcessing(t *testing.T) {
 // Property 2: Single IPv6 Result Processing
 func TestProperty_SingleIPv6ResultProcessing_BridgeConfiguration(t *testing.T) {
 	testCases := []struct {
-		name            string
-		ipv6Address     string
-		ipv6Gateway     string
-		maskBits        int
+		name             string
+		ipv6Address      string
+		ipv6Gateway      string
+		maskBits         int
 		expectedMaskBits int // mask applied by ConfigureBridge (may differ for ULA)
 	}{
 		{
-			name:            "global unicast IPv6",
-			ipv6Address:     "2001:db8::2",
-			ipv6Gateway:     "2001:db8::1",
-			maskBits:        64,
+			name:             "global unicast IPv6",
+			ipv6Address:      "2001:db8::2",
+			ipv6Gateway:      "2001:db8::1",
+			maskBits:         64,
 			expectedMaskBits: 64,
 		},
 		{
-			name:            "unique local address",
-			ipv6Address:     "fd00:ec2::2",
-			ipv6Gateway:     "fd00:ec2::1",
-			maskBits:        64,
+			name:             "unique local address",
+			ipv6Address:      "fd00:ec2::2",
+			ipv6Gateway:      "fd00:ec2::1",
+			maskBits:         64,
 			expectedMaskBits: 112, // ULA gets /112 mask
 		},
 	}
@@ -3390,7 +3391,7 @@ func TestProperty_SingleIPv6ResultProcessing_VethConfiguration(t *testing.T) {
 
 			mockLink := mock_netlink.NewMockLink(ctrl)
 			mockAttrs := &netlink.LinkAttrs{Index: 1}
-					routes := []netlink.Route{}
+			routes := []netlink.Route{}
 
 			gomock.InOrder(
 				mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
@@ -3398,7 +3399,7 @@ func TestProperty_SingleIPv6ResultProcessing_VethConfiguration(t *testing.T) {
 				mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 				mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 				mockIP.EXPECT().SetHWAddrByIP(interfaceName, nil, ipv6ContainerAddr).Return(nil),
-			mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
+				mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
 				mockLink.EXPECT().Attrs().Return(mockAttrs),
 				mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 			)
@@ -3776,7 +3777,7 @@ func TestProperty_DualStackResultProcessing_VethConfiguration(t *testing.T) {
 
 			mockLink := mock_netlink.NewMockLink(ctrl)
 			mockAttrs := &netlink.LinkAttrs{Index: 1}
-					routes := []netlink.Route{}
+			routes := []netlink.Route{}
 
 			gomock.InOrder(
 				mockNetLink.EXPECT().LinkByName(interfaceName).Return(mockLink, nil),
@@ -3787,7 +3788,7 @@ func TestProperty_DualStackResultProcessing_VethConfiguration(t *testing.T) {
 				mockIPAM.EXPECT().ConfigureIface(interfaceName, gomock.Any()).Return(nil),
 				// For dual-stack, SetHWAddrByIP uses both IPv4 and IPv6 addresses
 				mockIP.EXPECT().SetHWAddrByIP(interfaceName, ipv4ContainerAddr, ipv6ContainerAddr).Return(nil),
-			mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
+				mockNetLink.EXPECT().RouteList(mockLink, netlink.FAMILY_ALL).Return(routes, nil),
 				mockLink.EXPECT().Attrs().Return(mockAttrs),
 				mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(nil),
 				mockLink.EXPECT().Attrs().Return(mockAttrs),
@@ -3837,7 +3838,7 @@ func TestProperty_DualStackResultProcessing_DefaultRoutesDeletion(t *testing.T) 
 	}
 
 	mockLink := mock_netlink.NewMockLink(ctrl)
-		mockAttrs := &netlink.LinkAttrs{Index: 1}
+	mockAttrs := &netlink.LinkAttrs{Index: 1}
 
 	// Both IPv4 and IPv6 default routes present
 	ipv4DefaultRoute := netlink.Route{
@@ -3883,12 +3884,12 @@ func TestConnectedSubnetRoute_SkipWhenMaskSizeZero(t *testing.T) {
 	// Test that when mask size is 0, no connected subnet route is added
 	maskSize := 0
 	ipMask := net.CIDRMask(22, 32) // IPAM provides /22
-	
+
 	// Logic from configureveth.go lines 138-156
 	shouldAddRoute := maskSize != 0
-	
+
 	assert.False(t, shouldAddRoute, "should not add connected subnet route when mask size is 0")
-	
+
 	// Verify the mask would be used if it were non-zero
 	if maskSize != 0 {
 		ones, _ := ipMask.Size()
@@ -3902,12 +3903,12 @@ func TestConnectedSubnetRoute_AddWhenMaskSizeNonZero(t *testing.T) {
 	// Test that when mask size is non-zero, connected subnet route is added
 	maskSize := 22
 	ipMask := net.CIDRMask(22, 32) // IPAM provides /22
-	
+
 	// Logic from configureveth.go lines 138-156
 	shouldAddRoute := maskSize != 0
-	
+
 	assert.True(t, shouldAddRoute, "should add connected subnet route when mask size is non-zero")
-	
+
 	// Verify the correct mask is used
 	ones, _ := ipMask.Size()
 	assert.Equal(t, 22, ones, "connected subnet route should use /22 mask")
@@ -3917,9 +3918,9 @@ func TestConnectedSubnetRoute_AddWhenMaskSizeNonZero(t *testing.T) {
 // are NOT deleted during cleanup (preserves gateway routes)
 func TestConnectedSubnetRoute_PreserveHostRoutes(t *testing.T) {
 	testCases := []struct {
-		name          string
-		route         netlink.Route
-		shouldDelete  bool
+		name         string
+		route        netlink.Route
+		shouldDelete bool
 	}{
 		{
 			name: "/32 IPv4 route preserved",
@@ -3950,15 +3951,15 @@ func TestConnectedSubnetRoute_PreserveHostRoutes(t *testing.T) {
 			shouldDelete: true,
 		},
 	}
-	
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Logic from configureveth.go lines 118-133
 			ones, bits := tc.route.Dst.Mask.Size()
 			isHostRoute := (bits == 32 && ones == 32) || (bits == 128 && ones == 128)
 			shouldDelete := !isHostRoute
-			
-			assert.Equal(t, tc.shouldDelete, shouldDelete, 
+
+			assert.Equal(t, tc.shouldDelete, shouldDelete,
 				"route deletion decision should match expected")
 		})
 	}
@@ -3995,5 +3996,98 @@ func TestBlockInstanceMetadata(t *testing.T) {
 		err := engine.BlockInstanceMetadata(testNetNS)
 		assert.Error(t, err)
 		assert.Equal(t, expectedErr, err)
+	})
+}
+
+// TestBlockIMDSContextRun tests the blockIMDSContext.run() function directly
+func TestBlockIMDSContextRun(t *testing.T) {
+	t.Run("succeeds when routes do not exist", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockNetLink := mock_netlinkwrapper.NewMockNetLink(ctrl)
+		mockNetNS := mock_ns.NewMockNetNS(ctrl)
+
+		ctx := &blockIMDSContext{
+			netLink: mockNetLink,
+		}
+
+		for _, ep := range InstanceMetadataEndpoints {
+			_, imdsNetwork, err := net.ParseCIDR(ep)
+			assert.NoError(t, err)
+			mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
+				assert.Equal(t, imdsNetwork.String(), route.Dst.String())
+				assert.Equal(t, syscall.RTN_BLACKHOLE, route.Type)
+			}).Return(nil)
+		}
+
+		err := ctx.run(mockNetNS)
+		assert.NoError(t, err)
+	})
+
+	t.Run("succeeds when routes already exist (EEXIST)", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockNetLink := mock_netlinkwrapper.NewMockNetLink(ctrl)
+		mockNetNS := mock_ns.NewMockNetNS(ctrl)
+
+		ctx := &blockIMDSContext{
+			netLink: mockNetLink,
+		}
+
+		for _, ep := range InstanceMetadataEndpoints {
+			_, imdsNetwork, err := net.ParseCIDR(ep)
+			assert.NoError(t, err)
+			mockNetLink.EXPECT().RouteAdd(gomock.Any()).Do(func(route *netlink.Route) {
+				assert.Equal(t, imdsNetwork.String(), route.Dst.String())
+				assert.Equal(t, syscall.RTN_BLACKHOLE, route.Type)
+			}).Return(os.NewSyscallError("route", syscall.EEXIST))
+		}
+
+		err := ctx.run(mockNetNS)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns error for non-EEXIST failures", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockNetLink := mock_netlinkwrapper.NewMockNetLink(ctrl)
+		mockNetNS := mock_ns.NewMockNetNS(ctrl)
+
+		ctx := &blockIMDSContext{
+			netLink: mockNetLink,
+		}
+
+		// First endpoint fails with a non-EEXIST error
+		mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(errors.New("network unreachable"))
+
+		err := ctx.run(mockNetNS)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unable to add route to block instance metadata")
+	})
+
+	t.Run("returns error for first endpoint but not second when first has EEXIST", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockNetLink := mock_netlinkwrapper.NewMockNetLink(ctrl)
+		mockNetNS := mock_ns.NewMockNetNS(ctrl)
+
+		ctx := &blockIMDSContext{
+			netLink: mockNetLink,
+		}
+
+		// First endpoint returns EEXIST (should be skipped)
+		// Second endpoint returns a real error
+		gomock.InOrder(
+			mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(os.NewSyscallError("route", syscall.EEXIST)),
+			mockNetLink.EXPECT().RouteAdd(gomock.Any()).Return(errors.New("permission denied")),
+		)
+
+		err := ctx.run(mockNetNS)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unable to add route to block instance metadata")
 	})
 }

--- a/plugins/eni/engine/nsclosure.go
+++ b/plugins/eni/engine/nsclosure.go
@@ -16,6 +16,7 @@ package engine
 import (
 	"fmt"
 	"net"
+	"os"
 	"syscall"
 
 	"github.com/aws/amazon-ecs-cni-plugins/pkg/netlinkwrapper"
@@ -27,7 +28,7 @@ import (
 var (
 	// InstanceMetadataEndpoints is the list of EC2 instance metadata endpoints.
 	InstanceMetadataEndpoints = []string{"169.254.169.254/32", "fd00:ec2::254/128"}
-	linkWithMACNotFoundError = errors.New("engine: device with mac address not found")
+	linkWithMACNotFoundError  = errors.New("engine: device with mac address not found")
 )
 
 // setupNamespaceClosureContext wraps the parameters and the method to configure the container's namespace
@@ -147,19 +148,24 @@ func (closureContext *setupNamespaceClosureContext) run(_ ns.NetNS) error {
 
 	// Add a blackhole route for IMDS endpoint if required
 	if closureContext.blockIMDS {
-                for _, ep := range InstanceMetadataEndpoints {
-                        _, imdsNetwork, err := net.ParseCIDR(ep)
-                        if err != nil {
-                                // This should never happen as these IP addresses are hardcoded.
-                                return errors.Wrapf(err, "setupNamespaceClosure engine: unable to parse instance metadata endpoint")
-                        }
-                        if err = closureContext.netLink.RouteAdd(&netlink.Route{
-                                Dst:  imdsNetwork,
-                                Type: syscall.RTN_BLACKHOLE,
-                        }); err != nil {
-                                return errors.Wrapf(err, "setupNamespaceClosure engine: unable to add route to block instance metadata")
-                        }
-                }
+		for _, ep := range InstanceMetadataEndpoints {
+			_, imdsNetwork, err := net.ParseCIDR(ep)
+			if err != nil {
+				// This should never happen as these IP addresses are hardcoded.
+				return errors.Wrapf(err, "setupNamespaceClosure engine: unable to parse instance metadata endpoint")
+			}
+			if err = closureContext.netLink.RouteAdd(&netlink.Route{
+				Dst:  imdsNetwork,
+				Type: syscall.RTN_BLACKHOLE,
+			}); err != nil {
+				// If the route already exists, treat it as success since the
+				// desired state (IMDS blocked) is already achieved.
+				if os.IsExist(err) {
+					continue
+				}
+				return errors.Wrapf(err, "setupNamespaceClosure engine: unable to add route to block instance metadata")
+			}
+		}
 	}
 
 	// Setup IP routes for the gateways


### PR DESCRIPTION
### Summary

Fix daemon task launch failures caused by `BlockInstanceMetadata` failing with "file exists" when IMDS blackhole routes already exist in a persistent daemon network namespace.

### Implementation details

The daemon network namespace persists for the instance lifetime. When `StopDaemonNetNS()` tears down a daemon task, it removes the veth pair via CNI DEL but the IMDS blackhole routes remain (they have no device association — just `RTN_BLACKHOLE` with a `Dst`, no `LinkIndex`). On the next daemon task start, the agent invokes the ecs-bridge CNI plugin with `blockInstanceMetadata: true`, and `BlockInstanceMetadata()` calls `RouteAdd()` for a route that already exists, returning `EEXIST`.

The fix adds an `os.IsExist(err)` check in `blockIMDSContext.run()` (ecs-bridge plugin) and in the `setupNamespaceClosure` IMDS blocking loop (eni plugin). When `RouteAdd` returns `EEXIST`, the error is treated as success since the desired state (IMDS blocked) is already achieved, and execution continues to the next endpoint.

Files changed:
- `plugins/ecs-bridge/engine/engine.go` — Handle `EEXIST` in `blockIMDSContext.run()`
- `plugins/eni/engine/nsclosure.go` — Same fix in the eni plugin's IMDS blocking loop
- `plugins/ecs-bridge/engine/engine_test.go` — Unit tests for the idempotency fix
- `plugins/ecs-bridge/e2eTests/e2e_test.go` — E2E test validating bridge re-creation after deletion

### Testing

- Unit tests: 4 new test cases in `TestBlockIMDSContextRun` covering routes-don't-exist (existing behavior), routes-already-exist (EEXIST fix), non-EEXIST errors still propagate, and mixed EEXIST/real-error scenarios. All pass.
- E2E test: `TestAddBridgeAfterDeletion` validates the full ADD → DEL → delete bridge → ADD cycle succeeds. Passes on remote Linux host.
- Remote build (`make plugins`) passes cleanly.

New tests cover the changes: yes

### Description for the changelog

Bug - Make BlockInstanceMetadata idempotent by handling EEXIST when IMDS blackhole routes already exist in persistent daemon network namespaces

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
